### PR TITLE
4.05 fixes

### DIFF
--- a/src/deadArg.ml
+++ b/src/deadArg.ml
@@ -113,11 +113,10 @@ and check e =
                 _);
               _};
           _}],
-        { exp_desc = Texp_function (
-            _,
+        { exp_desc = Texp_function { cases =
             [{c_lhs = {pat_desc = Tpat_var (_, _); pat_loc = {loc_ghost = true; _}; _};
-              c_rhs = {exp_desc = Texp_apply (_, args); exp_loc = {loc_ghost = true; _}; _}; _}],
-            _);
+              c_rhs = {exp_desc = Texp_apply (_, args); exp_loc = {loc_ghost = true; _}; _}; _}];
+            _ };
           exp_loc = {loc_ghost = true; _};_}) ->
       process loc args
   | _ -> ()
@@ -126,7 +125,8 @@ and check e =
 let node_build loc expr =
   let rec loop loc expr =
     match expr.exp_desc with
-    | Texp_function (lab, [{c_lhs = {pat_type; _}; c_rhs = exp; _}], _) ->
+    | Texp_function { arg_label = lab;
+                      cases = [{c_lhs = {pat_type; _}; c_rhs = exp; _}]; _ } ->
         DeadType.check_style pat_type expr.exp_loc.Location.loc_start;
         begin match lab with
         | Asttypes.Optional s ->

--- a/src/deadObj.ml
+++ b/src/deadObj.ml
@@ -140,7 +140,7 @@ let rec treat_fields action typ = match typ.desc with
 let rec repr_exp expr f =
   match expr.exp_desc with
     | Texp_sequence (_, expr)
-    | Texp_function (_, {c_rhs=expr; _}::_, _)
+    | Texp_function { cases = {c_rhs=expr; _}::_ ; _ }
     | Texp_apply (expr, _) -> repr_exp expr f
     | _ -> f expr
 


### PR DESCRIPTION
The problem, of course, is that these changes break compatibility with older OCaml versions. But it is probably to keep `trunk` synchronized with recent or incoming upstream releases, and have `4.03`, `4.04` etc. branches for older versions you want to keep supporting.

I noticed the 4.05 build issue through [opam-builder](http://opam.ocamlpro.com/builder/html/report-full.html), and will edit the opam-repository metadata to mark the current release as unsupported on 4.05.