### PR TITLE
Adapt the tool to projects compiled with dune

### DIFF
--- a/src/deadFlag.ml
+++ b/src/deadFlag.ml
@@ -178,8 +178,7 @@ let internal = ref false
 let set_internal () = internal := true
 
 
-let exclude, is_excluded =
-  let tbl = Hashtbl.create 10 in
+let normalize_path s =
   let rec split_path s =
     let open Filename in
     if s = current_dir_name || s = dir_sep then [s]
@@ -189,14 +188,17 @@ let exclude, is_excluded =
     | [] -> []
     | x :: ((y :: _) as yss) when x = y && x = Filename.current_dir_name -> norm_path yss
     | x :: xss ->
-        let yss = List.filter (fun x -> x <> Filename.current_dir_name) xss in
-        x :: yss
+      let yss = List.filter (fun x -> x <> Filename.current_dir_name) xss in
+      x :: yss
   in
   let rec concat_path = function
     | [] -> ""
     | x :: xs -> Filename.concat x (concat_path xs)
   in
-  let normalize_path s = concat_path (norm_path (List.rev (split_path s))) in
+  concat_path (norm_path (List.rev (split_path s)))
+
+let exclude, is_excluded =
+  let tbl = Hashtbl.create 10 in
   let exclude s = Hashtbl.replace tbl (normalize_path s) () in
   let is_excluded s = Hashtbl.mem tbl (normalize_path s) in
   exclude, is_excluded

--- a/src/deadFlag.ml
+++ b/src/deadFlag.ml
@@ -182,7 +182,7 @@ let exclude, is_excluded =
   let tbl = Hashtbl.create 10 in
   let rec split_path s =
     let open Filename in
-    if s = current_dir_name then [s]
+    if s = current_dir_name || s = dir_sep then [s]
     else (basename s) :: (split_path (dirname s))
   in
   let rec norm_path = function


### PR DESCRIPTION
After compiling project with dune, it will generates the `*.cmi`/`*.cmt` files in a separate folder named `.<name>.objs` or `.<name>.eobjs`. Refer to: https://github.com/ocaml/dune/blob/master/src/utils.ml#L111 and https://github.com/ocaml/dune/blob/master/src/utils.ml#L116

For example:
When compiling https://github.com/xapi-project/xen-api project (Of course I haved added the flag `-keep-locs` and `-bin-annot`), the `cmi` and `cmt` files will be put into `_build/default/ocaml/xapi/.xapi_internal.objs/` while the corresponding `mli` and `ml` files are in `_build/default/ocaml/xapi`.

So this patch aims to fix the search path when searching source files.

P.S. It also contains the fix of https://github.com/LexiFi/dead_code_analyzer/issues/8 as a separate small commit.