### PR TITLE
fix path lookup, improve 4.05/4.06  support (pass 100% of make check), add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: c
+sudo: false
+dist: trusty
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+script: bash -ex .travis-docker.sh
+env:
+  global:
+      - DISTRO="ubuntu-16.04"
+      - PACKAGE="dead_code_analyzer"
+  matrix:
+      - OCAML_VERSION=4.05.0
+      - OCAML_VERSION=4.06.0

--- a/check/aggregate.ml
+++ b/check/aggregate.ml
@@ -72,5 +72,8 @@ let () =
   print_endline "~~~~~~~~~~~~~~~~~~~~~~~";
   print_endline "|                     |";
   print_endline "[>  Unified Results  <]";
-  print_res     "|                     |" total err
+  print_res     "|                     |" total err;
+
+  if err > 0 then
+    exit 1
 

--- a/opam
+++ b/opam
@@ -11,4 +11,5 @@ bug-reports: "https://github.com/LexiFi/dead_code_analyzer/issues"
 license: "MIT"
 dev-repo: "https://github.com/LexiFi/dead_code_analyzer.git"
 build: [make "all" "opt" "man"]
-available: [ocaml-version = "4.05.0"]
+build-test : [make "check"]
+available: [ocaml-version >= "4.05.0"]

--- a/src/deadArg.ml
+++ b/src/deadArg.ml
@@ -110,7 +110,7 @@ and check e =
         [{vb_expr =
             { exp_desc = Texp_apply (
                 {exp_desc = Texp_ident (_, _, {val_loc = {Location.loc_start = loc; _}; _}); _},
-                _);
+                _) | Texp_ident(_, _, {val_loc = {Location.loc_start = loc; _}; _});
               _};
           _}],
         { exp_desc = Texp_function { cases =

--- a/src/deadCode.ml
+++ b/src/deadCode.ml
@@ -357,12 +357,16 @@ let kind fn =
     if Filename.check_suffix fn ".cmi" then
       let base = Filename.chop_suffix fn ".cmi" in
       match good_exts base [".mli"; ".mfi"; ".ml"; ".mf"; ".mll"; ".mfl"] with
-      | "" -> `Ignore
+      | "" ->
+        if !DeadFlag.verbose then Printf.eprintf "Ignoring %s (no source?)\n%!" base;
+        `Ignore
       | src -> `Iface src
     else if Filename.check_suffix fn ".cmt" then
       let base = Filename.chop_suffix fn ".cmt" in
       match good_exts base [".ml"; ".mf"; ".mll"; ".mfl"] with
-      | "" -> `Ignore
+      | "" ->
+        if !DeadFlag.verbose then Printf.eprintf "Ignoring %s (no source?)\n%!" base;
+        `Ignore
       | src -> `Implem src
     else if Sys.is_directory fn       then  `Dir
     else            (* default *)           `Ignore

--- a/src/deadCode.ml
+++ b/src/deadCode.ml
@@ -312,6 +312,16 @@ let ends_with suffix s =
   if len > s_len then false
   else String.sub s (s_len - len) len = suffix
 
+let remove_wrap name =
+  let n = String.length name in
+  let rec loop i =
+    if i < n - 1 then
+      if name.[i] == '_' && name.[i+1] == '_' then
+        String.uncapitalize_ascii (String.sub name (i+2) (n - i - 2))
+      else loop (i+1)
+    else name
+  in loop 0
+
 (* Checks the nature of the file *)
 let kind fn =
   if not (Sys.file_exists fn) then begin
@@ -336,7 +346,7 @@ let kind fn =
         in
         if starts_with "." cur_dir
         && (ends_with ".objs" cur_dir || ends_with ".eobjs" cur_dir) then begin
-          let f = Filename.basename base in
+          let f = remove_wrap (Filename.basename base) in
           Some (Filename.concat upper_d f)
         end
         else None

--- a/src/deadCode.ml
+++ b/src/deadCode.ml
@@ -327,7 +327,8 @@ let kind fn =
         let fn = base ^ ext in
         Sys.file_exists fn && not (is_excluded fn)
       in
-      let base = normalize_path base in
+      (* normalize_path would append a slash, use it only on the dirname *)
+      let base = Filename.(concat (normalize_path (dirname base)) (basename base)) in
       let upper_base =
         let upper_d, cur_dir =
           let d = Filename.dirname base in

--- a/src/deadFlag.ml
+++ b/src/deadFlag.ml
@@ -188,6 +188,8 @@ let normalize_path s =
     | [] -> []
     | x :: ((y :: _) as yss) when x = y && x = Filename.current_dir_name -> norm_path yss
     | x :: xss ->
+      if x = Filename.current_dir_name then norm_path xss (* strip leading ./ *)
+      else
       let yss = List.filter (fun x -> x <> Filename.current_dir_name) xss in
       x :: yss
   in

--- a/src/deadObj.ml
+++ b/src/deadObj.ml
@@ -341,7 +341,7 @@ let arg typ args =
           arg self typ (List.tl args)
       | Tarrow (_, _, typ, _) ->
           arg self typ args
-      | Tobject _ ->
+      | Tobject _ when not self ->
           let f exp =
             treat_fields
               (fun s ->


### PR DESCRIPTION
`make check` will now succeed on master, see commit messages for individual changes.
Tested on OCaml 4.06.1 locally (Linux), and OCaml 4.05.0/4.06.0 on Travis.

This should fix #10 and be useful for #6 

Not sure why we need to look up the source file name based on the binary object file name, surely the `.cmi/.cmt` files themselves should have enough location information inside them to determine what the real source is without making assumptions about the build system?