### PR TITLE
Fix unified results' failed count

### DIFF
--- a/check/src/aggregate.ml
+++ b/check/src/aggregate.ml
@@ -62,14 +62,9 @@ let update state line =
     StringSet.add line set
   in
   let state =
-    let end_of_fp = "Should not be detected" ^ PP.style_reset in
-    let end_of_fn = "Not detected" ^ PP.style_reset in
-    if String.starts_with ~prefix:(Filename.concat "." "examples") line then
-      let unique_success_lines =
-        add_unique_line state.State.unique_success_lines
-      in
-      {state with unique_success_lines}
-    else if
+    let end_of_fp = "Should not be detected" in
+    let end_of_fn = "Not detected" in
+    if
       String.ends_with ~suffix:end_of_fp line
       || String.ends_with ~suffix:end_of_fn line
     then
@@ -77,6 +72,11 @@ let update state line =
         add_unique_line state.State.unique_failure_lines
       in
       {state with unique_failure_lines}
+    else if String.starts_with ~prefix:(Filename.concat "." "examples") line then
+      let unique_success_lines =
+        add_unique_line state.State.unique_success_lines
+      in
+      {state with unique_success_lines}
     else state
   in
   let get ~default extract_from =


### PR DESCRIPTION
When running `make -C check stats`, the unified results' failed count was always `0`. This was due to the absence of colors when printing to a file (commit 2186cb1). This fixes it by changing the order of conditions and the expected end of line for failure lines.

Only creating this PR for traceability.