### PR TITLE
Fix report line comparison

### DIFF
--- a/check/src/check.ml
+++ b/check/src/check.ml
@@ -121,13 +121,13 @@ and process_mismatch state exp_lines got_lines =
     in
     let handle_report_infos alt state =
       (* If either is not a valid report line, then it is consumed.
-         If both are valid report_lines then the first in lexicographical order
-         is consumed *)
+         If both are valid report_lines then the first that should appear in
+         the report order is consumed *)
       let exp_ri = Reports.report_info_of_line exp in
       let got_ri = Reports.report_info_of_line got in
       match exp_ri, got_ri with
-      | Ok _, Ok _ ->
-        let comp = String.compare exp got in
+      | Ok exp_ri, Ok got_ri ->
+        let comp = Reports.compare exp_ri got_ri in
         assert (comp <> 0);
         if comp < 0 then consume_exp state
         else (* > 0 *)   consume_got state

--- a/check/src/reports.ml
+++ b/check/src/reports.ml
@@ -4,6 +4,12 @@ type report_info = {
   value : string;
 }
 
+let compare ri1 ri2 =
+  let ( |:? ) x f = if x <> 0 then x else f () in
+  String.compare ri1.filepath ri2.filepath
+  |:? (fun () -> Int.compare ri1.line_nb ri2.line_nb)
+  |:? (fun () -> String.compare ri1.value ri2.value)
+
 let line_of_report_info ri =
   Printf.sprintf "%s:%d:%s" ri.filepath ri.line_nb ri.value
 

--- a/check/src/reports.mli
+++ b/check/src/reports.mli
@@ -4,6 +4,8 @@ type report_info = {
   value : string;
 }
 
+val compare : report_info -> report_info -> int
+
 val line_of_report_info : report_info -> string
 
 (* Format of report lines is : '<file_path>:<line_number>:<value>' with :


### PR DESCRIPTION
The comparison was on the whole line at one to obtain a lexicographical order. This ordering is to shallow for report lines and an invalid ordering would be expected for e.g. `foo.ml:9: x` and `foo.ml:10: x`, and wrongful FN/FP may be reported.

Now, they are compared closer to how the analyzer does it : by filename first, then by line (the analyzer actually has more precise locations internally), then by value.

Only creating this PR for traceability.