### PR TITLE
Strengthen report semantic for API "re-exports"

### DIFF
--- a/check/classic/classic.exp
+++ b/check/classic/classic.exp
@@ -5,6 +5,21 @@
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:38: internally_used_f
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:2: unused
 
+./examples/using_dune/reduced_lib/reduced_lib.mli:3: Values.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:4: Values.internally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:10: Values_no_intf.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:11: Values_no_intf.internally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:18: Values_in_submodules.Exported.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:19: Values_in_submodules.Exported.internally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:27: Values_in_submodules_no_intf.Exported.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:28: Values_in_submodules_no_intf.Exported.internally_used
+./examples/using_dune/reduced_lib/values.mli:7: lib_internal_unused
+./examples/using_dune/reduced_lib/values.mli:8: lib_internal_internally_used
+./examples/using_dune/reduced_lib/values_in_submodules.mli:8: Exported.lib_internal_unused
+./examples/using_dune/reduced_lib/values_in_submodules.mli:9: Exported.lib_internal_internally_used
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:8: Exported.lib_internal_unused
+./examples/using_dune/reduced_lib/values_no_intf.ml:11: lib_internal_unused
+
 ./examples/using_dune/unwrapped_lib/opt_args/opt_args.mli:1: unused_fun_with_single_never_used_opt_arg
 ./examples/using_dune/unwrapped_lib/opt_args/opt_args.mli:8: internally_used_fun_with_single_never_used_opt_arg
 ./examples/using_dune/unwrapped_lib/opt_args/opt_args.mli:10: internally_used_fun_with_single_always_used_opt_arg

--- a/check/classic/classic.ref
+++ b/check/classic/classic.ref
@@ -5,6 +5,21 @@
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:38: internally_used_f
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:2: unused
 
+./examples/using_dune/reduced_lib/reduced_lib.mli:3: Values.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:4: Values.internally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:10: Values_no_intf.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:11: Values_no_intf.internally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:18: Values_in_submodules.Exported.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:19: Values_in_submodules.Exported.internally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:27: Values_in_submodules_no_intf.Exported.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:28: Values_in_submodules_no_intf.Exported.internally_used
+./examples/using_dune/reduced_lib/values.mli:7: lib_internal_unused
+./examples/using_dune/reduced_lib/values.mli:8: lib_internal_internally_used
+./examples/using_dune/reduced_lib/values_in_submodules.mli:8: Exported.lib_internal_unused
+./examples/using_dune/reduced_lib/values_in_submodules.mli:9: Exported.lib_internal_internally_used
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:8: Exported.lib_internal_unused
+./examples/using_dune/reduced_lib/values_no_intf.ml:11: lib_internal_unused
+
 ./examples/using_dune/unwrapped_lib/opt_args/opt_args.mli:1: unused_fun_with_single_never_used_opt_arg
 ./examples/using_dune/unwrapped_lib/opt_args/opt_args.mli:8: internally_used_fun_with_single_never_used_opt_arg
 ./examples/using_dune/unwrapped_lib/opt_args/opt_args.mli:10: internally_used_fun_with_single_always_used_opt_arg
@@ -550,7 +565,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 477
-Success: 477
+Total: 491
+Success: 491
 Failed: 0
 Ratio: 100.%

--- a/check/internal/internal.exp
+++ b/check/internal/internal.exp
@@ -3,6 +3,19 @@
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:2: unused
 
+./examples/using_dune/reduced_lib/reduced_lib.mli:3: Values.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:4: Values.internally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:10: Values_no_intf.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:11: Values_no_intf.internally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:18: Values_in_submodules.Exported.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:19: Values_in_submodules.Exported.internally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:27: Values_in_submodules_no_intf.Exported.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:28: Values_in_submodules_no_intf.Exported.internally_used
+./examples/using_dune/reduced_lib/values.mli:7: lib_internal_unused
+./examples/using_dune/reduced_lib/values_in_submodules.mli:8: Exported.lib_internal_unused
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:8: Exported.lib_internal_unused
+./examples/using_dune/reduced_lib/values_no_intf.ml:11: lib_internal_unused
+
 ./examples/using_dune/unwrapped_lib/opt_args/opt_args.mli:1: unused_fun_with_single_never_used_opt_arg
 
 ./examples/using_dune/unwrapped_lib/values/values.mli:2: unused_int

--- a/check/internal/internal.ref
+++ b/check/internal/internal.ref
@@ -3,6 +3,19 @@
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:2: unused
 
+./examples/using_dune/reduced_lib/reduced_lib.mli:3: Values.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:4: Values.internally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:10: Values_no_intf.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:11: Values_no_intf.internally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:18: Values_in_submodules.Exported.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:19: Values_in_submodules.Exported.internally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:27: Values_in_submodules_no_intf.Exported.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:28: Values_in_submodules_no_intf.Exported.internally_used
+./examples/using_dune/reduced_lib/values.mli:7: lib_internal_unused
+./examples/using_dune/reduced_lib/values_in_submodules.mli:8: Exported.lib_internal_unused
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:8: Exported.lib_internal_unused
+./examples/using_dune/reduced_lib/values_no_intf.ml:11: lib_internal_unused
+
 ./examples/using_dune/unwrapped_lib/opt_args/opt_args.mli:1: unused_fun_with_single_never_used_opt_arg
 
 ./examples/using_dune/unwrapped_lib/values/values.mli:2: unused_int
@@ -517,7 +530,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 446
-Success: 446
+Total: 458
+Success: 458
 Failed: 0
 Ratio: 100.%

--- a/check/threshold-1/threshold-1.exp
+++ b/check/threshold-1/threshold-1.exp
@@ -3,6 +3,19 @@
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:2: unused
 
+./examples/using_dune/reduced_lib/reduced_lib.mli:3: Values.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:4: Values.internally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:10: Values_no_intf.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:11: Values_no_intf.internally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:18: Values_in_submodules.Exported.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:19: Values_in_submodules.Exported.internally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:27: Values_in_submodules_no_intf.Exported.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:28: Values_in_submodules_no_intf.Exported.internally_used
+./examples/using_dune/reduced_lib/values.mli:7: lib_internal_unused
+./examples/using_dune/reduced_lib/values_in_submodules.mli:8: Exported.lib_internal_unused
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:8: Exported.lib_internal_unused
+./examples/using_dune/reduced_lib/values_no_intf.ml:11: lib_internal_unused
+
 ./examples/using_dune/unwrapped_lib/opt_args/opt_args.mli:1: unused_fun_with_single_never_used_opt_arg
 
 ./examples/using_dune/unwrapped_lib/values/values.mli:2: unused_int
@@ -75,6 +88,12 @@
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_lib.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_no_intf.mli:1: mark_used
 
+./examples/using_dune/bin/use_reduced_lib/use_reduced_lib.mli:1: mark_used
+./examples/using_dune/bin/use_reduced_lib/use_values.mli:1: mark_used
+./examples/using_dune/bin/use_reduced_lib/use_values_in_submodules.mli:1: mark_used
+./examples/using_dune/bin/use_reduced_lib/use_values_in_submodules_no_intf.mli:1: mark_used
+./examples/using_dune/bin/use_reduced_lib/use_values_no_intf.mli:1: mark_used
+
 ./examples/using_dune/bin/use_unwrapped_lib/use_builder_sig_api.mli:1: mark_used
 ./examples/using_dune/bin/use_unwrapped_lib/use_constructors.mli:1: mark_used
 ./examples/using_dune/bin/use_unwrapped_lib/use_include_modtype.mli:1: mark_used
@@ -111,6 +130,31 @@
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:4: externally_used
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:4: internally_used
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:5: externally_used
+
+./examples/using_dune/reduced_lib/reduced_lib.mli:2: Values.used
+./examples/using_dune/reduced_lib/reduced_lib.mli:5: Values.externally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:9: Values_no_intf.used
+./examples/using_dune/reduced_lib/reduced_lib.mli:12: Values_no_intf.externally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:17: Values_in_submodules.Exported.used
+./examples/using_dune/reduced_lib/reduced_lib.mli:20: Values_in_submodules.Exported.externally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:26: Values_in_submodules_no_intf.Exported.used
+./examples/using_dune/reduced_lib/reduced_lib.mli:29: Values_in_submodules_no_intf.Exported.externally_used
+./examples/using_dune/reduced_lib/values.mli:2: used_by_API
+./examples/using_dune/reduced_lib/values.mli:4: externally_used
+./examples/using_dune/reduced_lib/values.mli:8: lib_internal_internally_used
+./examples/using_dune/reduced_lib/values.mli:9: lib_internal_externally_used
+./examples/using_dune/reduced_lib/values_in_submodules.mli:3: Exported.used_by_API
+./examples/using_dune/reduced_lib/values_in_submodules.mli:5: Exported.externally_used
+./examples/using_dune/reduced_lib/values_in_submodules.mli:9: Exported.lib_internal_internally_used
+./examples/using_dune/reduced_lib/values_in_submodules.mli:10: Exported.lib_internal_externally_used
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:3: Exported.used_by_API
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:5: Exported.externally_used
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:9: Exported.lib_internal_internally_used
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:10: Exported.lib_internal_externally_used
+./examples/using_dune/reduced_lib/values_no_intf.ml:2: used_by_API
+./examples/using_dune/reduced_lib/values_no_intf.ml:4: externally_used
+./examples/using_dune/reduced_lib/values_no_intf.ml:12: lib_internal_internally_used
+./examples/using_dune/reduced_lib/values_no_intf.ml:13: lib_internal_externally_used
 
 ./examples/using_dune/unwrapped_lib/opt_args/opt_args.mli:8: internally_used_fun_with_single_never_used_opt_arg
 ./examples/using_dune/unwrapped_lib/opt_args/opt_args.mli:10: internally_used_fun_with_single_always_used_opt_arg

--- a/check/threshold-1/threshold-1.ref
+++ b/check/threshold-1/threshold-1.ref
@@ -140,19 +140,19 @@
 ./examples/using_dune/reduced_lib/reduced_lib.mli:26: Values_in_submodules_no_intf.Exported.used
 ./examples/using_dune/reduced_lib/reduced_lib.mli:29: Values_in_submodules_no_intf.Exported.externally_used
 ./examples/using_dune/reduced_lib/values.mli:2: used_by_API
-./examples/using_dune/reduced_lib/values.mli:4: externally_used: Not detected
+./examples/using_dune/reduced_lib/values.mli:4: externally_used
 ./examples/using_dune/reduced_lib/values.mli:8: lib_internal_internally_used
 ./examples/using_dune/reduced_lib/values.mli:9: lib_internal_externally_used
 ./examples/using_dune/reduced_lib/values_in_submodules.mli:3: Exported.used_by_API
-./examples/using_dune/reduced_lib/values_in_submodules.mli:5: Exported.externally_used: Not detected
+./examples/using_dune/reduced_lib/values_in_submodules.mli:5: Exported.externally_used
 ./examples/using_dune/reduced_lib/values_in_submodules.mli:9: Exported.lib_internal_internally_used
 ./examples/using_dune/reduced_lib/values_in_submodules.mli:10: Exported.lib_internal_externally_used
 ./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:3: Exported.used_by_API
-./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:5: Exported.externally_used: Not detected
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:5: Exported.externally_used
 ./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:9: Exported.lib_internal_internally_used
 ./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:10: Exported.lib_internal_externally_used
 ./examples/using_dune/reduced_lib/values_no_intf.ml:2: used_by_API
-./examples/using_dune/reduced_lib/values_no_intf.ml:4: externally_used: Not detected
+./examples/using_dune/reduced_lib/values_no_intf.ml:4: externally_used
 ./examples/using_dune/reduced_lib/values_no_intf.ml:12: lib_internal_internally_used
 ./examples/using_dune/reduced_lib/values_no_intf.ml:13: lib_internal_externally_used
 
@@ -874,6 +874,6 @@ Nothing else to report in this section
 
 
 Total: 762
-Success: 758
-Failed: 4
-Ratio: 99.4750656168%
+Success: 762
+Failed: 0
+Ratio: 100.%

--- a/check/threshold-1/threshold-1.ref
+++ b/check/threshold-1/threshold-1.ref
@@ -3,6 +3,19 @@
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:2: unused
 
+./examples/using_dune/reduced_lib/reduced_lib.mli:3: Values.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:4: Values.internally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:10: Values_no_intf.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:11: Values_no_intf.internally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:18: Values_in_submodules.Exported.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:19: Values_in_submodules.Exported.internally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:27: Values_in_submodules_no_intf.Exported.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:28: Values_in_submodules_no_intf.Exported.internally_used
+./examples/using_dune/reduced_lib/values.mli:7: lib_internal_unused
+./examples/using_dune/reduced_lib/values_in_submodules.mli:8: Exported.lib_internal_unused
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:8: Exported.lib_internal_unused
+./examples/using_dune/reduced_lib/values_no_intf.ml:11: lib_internal_unused
+
 ./examples/using_dune/unwrapped_lib/opt_args/opt_args.mli:1: unused_fun_with_single_never_used_opt_arg
 
 ./examples/using_dune/unwrapped_lib/values/values.mli:2: unused_int
@@ -75,6 +88,12 @@
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_lib.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_no_intf.mli:1: mark_used
 
+./examples/using_dune/bin/use_reduced_lib/use_reduced_lib.mli:1: mark_used
+./examples/using_dune/bin/use_reduced_lib/use_values.mli:1: mark_used
+./examples/using_dune/bin/use_reduced_lib/use_values_in_submodules.mli:1: mark_used
+./examples/using_dune/bin/use_reduced_lib/use_values_in_submodules_no_intf.mli:1: mark_used
+./examples/using_dune/bin/use_reduced_lib/use_values_no_intf.mli:1: mark_used
+
 ./examples/using_dune/bin/use_unwrapped_lib/use_builder_sig_api.mli:1: mark_used
 ./examples/using_dune/bin/use_unwrapped_lib/use_constructors.mli:1: mark_used
 ./examples/using_dune/bin/use_unwrapped_lib/use_include_modtype.mli:1: mark_used
@@ -111,6 +130,31 @@
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:4: externally_used
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:4: internally_used
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:5: externally_used
+
+./examples/using_dune/reduced_lib/reduced_lib.mli:2: Values.used
+./examples/using_dune/reduced_lib/reduced_lib.mli:5: Values.externally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:9: Values_no_intf.used
+./examples/using_dune/reduced_lib/reduced_lib.mli:12: Values_no_intf.externally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:17: Values_in_submodules.Exported.used
+./examples/using_dune/reduced_lib/reduced_lib.mli:20: Values_in_submodules.Exported.externally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:26: Values_in_submodules_no_intf.Exported.used
+./examples/using_dune/reduced_lib/reduced_lib.mli:29: Values_in_submodules_no_intf.Exported.externally_used
+./examples/using_dune/reduced_lib/values.mli:2: used_by_API
+./examples/using_dune/reduced_lib/values.mli:4: externally_used: Not detected
+./examples/using_dune/reduced_lib/values.mli:8: lib_internal_internally_used
+./examples/using_dune/reduced_lib/values.mli:9: lib_internal_externally_used
+./examples/using_dune/reduced_lib/values_in_submodules.mli:3: Exported.used_by_API
+./examples/using_dune/reduced_lib/values_in_submodules.mli:5: Exported.externally_used: Not detected
+./examples/using_dune/reduced_lib/values_in_submodules.mli:9: Exported.lib_internal_internally_used
+./examples/using_dune/reduced_lib/values_in_submodules.mli:10: Exported.lib_internal_externally_used
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:3: Exported.used_by_API
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:5: Exported.externally_used: Not detected
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:9: Exported.lib_internal_internally_used
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:10: Exported.lib_internal_externally_used
+./examples/using_dune/reduced_lib/values_no_intf.ml:2: used_by_API
+./examples/using_dune/reduced_lib/values_no_intf.ml:4: externally_used: Not detected
+./examples/using_dune/reduced_lib/values_no_intf.ml:12: lib_internal_internally_used
+./examples/using_dune/reduced_lib/values_no_intf.ml:13: lib_internal_externally_used
 
 ./examples/using_dune/unwrapped_lib/opt_args/opt_args.mli:8: internally_used_fun_with_single_never_used_opt_arg
 ./examples/using_dune/unwrapped_lib/opt_args/opt_args.mli:10: internally_used_fun_with_single_always_used_opt_arg
@@ -829,7 +873,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 721
-Success: 721
-Failed: 0
-Ratio: 100.%
+Total: 762
+Success: 758
+Failed: 4
+Ratio: 99.4750656168%

--- a/check/threshold-3-0.5/threshold-3-0.5.exp
+++ b/check/threshold-3-0.5/threshold-3-0.5.exp
@@ -3,6 +3,19 @@
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:2: unused
 
+./examples/using_dune/reduced_lib/reduced_lib.mli:3: Values.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:4: Values.internally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:10: Values_no_intf.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:11: Values_no_intf.internally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:18: Values_in_submodules.Exported.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:19: Values_in_submodules.Exported.internally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:27: Values_in_submodules_no_intf.Exported.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:28: Values_in_submodules_no_intf.Exported.internally_used
+./examples/using_dune/reduced_lib/values.mli:7: lib_internal_unused
+./examples/using_dune/reduced_lib/values_in_submodules.mli:8: Exported.lib_internal_unused
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:8: Exported.lib_internal_unused
+./examples/using_dune/reduced_lib/values_no_intf.ml:11: lib_internal_unused
+
 ./examples/using_dune/unwrapped_lib/opt_args/opt_args.mli:1: unused_fun_with_single_never_used_opt_arg
 
 ./examples/using_dune/unwrapped_lib/values/values.mli:2: unused_int
@@ -75,6 +88,12 @@
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_lib.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_no_intf.mli:1: mark_used
 
+./examples/using_dune/bin/use_reduced_lib/use_reduced_lib.mli:1: mark_used
+./examples/using_dune/bin/use_reduced_lib/use_values.mli:1: mark_used
+./examples/using_dune/bin/use_reduced_lib/use_values_in_submodules.mli:1: mark_used
+./examples/using_dune/bin/use_reduced_lib/use_values_in_submodules_no_intf.mli:1: mark_used
+./examples/using_dune/bin/use_reduced_lib/use_values_no_intf.mli:1: mark_used
+
 ./examples/using_dune/bin/use_unwrapped_lib/use_builder_sig_api.mli:1: mark_used
 ./examples/using_dune/bin/use_unwrapped_lib/use_constructors.mli:1: mark_used
 ./examples/using_dune/bin/use_unwrapped_lib/use_include_modtype.mli:1: mark_used
@@ -111,6 +130,31 @@
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:4: externally_used
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:4: internally_used
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:5: externally_used
+
+./examples/using_dune/reduced_lib/reduced_lib.mli:2: Values.used
+./examples/using_dune/reduced_lib/reduced_lib.mli:5: Values.externally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:9: Values_no_intf.used
+./examples/using_dune/reduced_lib/reduced_lib.mli:12: Values_no_intf.externally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:17: Values_in_submodules.Exported.used
+./examples/using_dune/reduced_lib/reduced_lib.mli:20: Values_in_submodules.Exported.externally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:26: Values_in_submodules_no_intf.Exported.used
+./examples/using_dune/reduced_lib/reduced_lib.mli:29: Values_in_submodules_no_intf.Exported.externally_used
+./examples/using_dune/reduced_lib/values.mli:2: used_by_API
+./examples/using_dune/reduced_lib/values.mli:4: externally_used
+./examples/using_dune/reduced_lib/values.mli:8: lib_internal_internally_used
+./examples/using_dune/reduced_lib/values.mli:9: lib_internal_externally_used
+./examples/using_dune/reduced_lib/values_in_submodules.mli:3: Exported.used_by_API
+./examples/using_dune/reduced_lib/values_in_submodules.mli:5: Exported.externally_used
+./examples/using_dune/reduced_lib/values_in_submodules.mli:9: Exported.lib_internal_internally_used
+./examples/using_dune/reduced_lib/values_in_submodules.mli:10: Exported.lib_internal_externally_used
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:3: Exported.used_by_API
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:5: Exported.externally_used
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:9: Exported.lib_internal_internally_used
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:10: Exported.lib_internal_externally_used
+./examples/using_dune/reduced_lib/values_no_intf.ml:2: used_by_API
+./examples/using_dune/reduced_lib/values_no_intf.ml:4: externally_used
+./examples/using_dune/reduced_lib/values_no_intf.ml:12: lib_internal_internally_used
+./examples/using_dune/reduced_lib/values_no_intf.ml:13: lib_internal_externally_used
 
 ./examples/using_dune/unwrapped_lib/opt_args/opt_args.mli:8: internally_used_fun_with_single_never_used_opt_arg
 ./examples/using_dune/unwrapped_lib/opt_args/opt_args.mli:10: internally_used_fun_with_single_always_used_opt_arg
@@ -251,6 +295,19 @@
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:53: f
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:59: internally_used_f
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:64: externally_used_f
+
+./examples/using_dune/reduced_lib/values.mli:1: used
+./examples/using_dune/reduced_lib/values.mli:3: internally_used
+./examples/using_dune/reduced_lib/values.mli:6: lib_internal_used
+./examples/using_dune/reduced_lib/values_in_submodules.mli:2: Exported.used
+./examples/using_dune/reduced_lib/values_in_submodules.mli:4: Exported.internally_used
+./examples/using_dune/reduced_lib/values_in_submodules.mli:7: Exported.lib_internal_used
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:2: Exported.used
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:4: Exported.internally_used
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:7: Exported.lib_internal_used
+./examples/using_dune/reduced_lib/values_no_intf.ml:1: used
+./examples/using_dune/reduced_lib/values_no_intf.ml:3: internally_used
+./examples/using_dune/reduced_lib/values_no_intf.ml:10: lib_internal_used
 
 ./examples/using_dune/unwrapped_lib/obj/with_class.mli:33: fun_class_factory
 

--- a/check/threshold-3-0.5/threshold-3-0.5.ref
+++ b/check/threshold-3-0.5/threshold-3-0.5.ref
@@ -3,6 +3,19 @@
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:2: unused
 
+./examples/using_dune/reduced_lib/reduced_lib.mli:3: Values.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:4: Values.internally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:10: Values_no_intf.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:11: Values_no_intf.internally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:18: Values_in_submodules.Exported.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:19: Values_in_submodules.Exported.internally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:27: Values_in_submodules_no_intf.Exported.used_by_API
+./examples/using_dune/reduced_lib/reduced_lib.mli:28: Values_in_submodules_no_intf.Exported.internally_used
+./examples/using_dune/reduced_lib/values.mli:7: lib_internal_unused
+./examples/using_dune/reduced_lib/values_in_submodules.mli:8: Exported.lib_internal_unused
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:8: Exported.lib_internal_unused
+./examples/using_dune/reduced_lib/values_no_intf.ml:11: lib_internal_unused
+
 ./examples/using_dune/unwrapped_lib/opt_args/opt_args.mli:1: unused_fun_with_single_never_used_opt_arg
 
 ./examples/using_dune/unwrapped_lib/values/values.mli:2: unused_int
@@ -75,6 +88,12 @@
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_lib.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_no_intf.mli:1: mark_used
 
+./examples/using_dune/bin/use_reduced_lib/use_reduced_lib.mli:1: mark_used
+./examples/using_dune/bin/use_reduced_lib/use_values.mli:1: mark_used
+./examples/using_dune/bin/use_reduced_lib/use_values_in_submodules.mli:1: mark_used
+./examples/using_dune/bin/use_reduced_lib/use_values_in_submodules_no_intf.mli:1: mark_used
+./examples/using_dune/bin/use_reduced_lib/use_values_no_intf.mli:1: mark_used
+
 ./examples/using_dune/bin/use_unwrapped_lib/use_builder_sig_api.mli:1: mark_used
 ./examples/using_dune/bin/use_unwrapped_lib/use_constructors.mli:1: mark_used
 ./examples/using_dune/bin/use_unwrapped_lib/use_include_modtype.mli:1: mark_used
@@ -111,6 +130,31 @@
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:4: externally_used
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:4: internally_used
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:5: externally_used
+
+./examples/using_dune/reduced_lib/reduced_lib.mli:2: Values.used
+./examples/using_dune/reduced_lib/reduced_lib.mli:5: Values.externally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:9: Values_no_intf.used
+./examples/using_dune/reduced_lib/reduced_lib.mli:12: Values_no_intf.externally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:17: Values_in_submodules.Exported.used
+./examples/using_dune/reduced_lib/reduced_lib.mli:20: Values_in_submodules.Exported.externally_used
+./examples/using_dune/reduced_lib/reduced_lib.mli:26: Values_in_submodules_no_intf.Exported.used
+./examples/using_dune/reduced_lib/reduced_lib.mli:29: Values_in_submodules_no_intf.Exported.externally_used
+./examples/using_dune/reduced_lib/values.mli:2: used_by_API
+./examples/using_dune/reduced_lib/values.mli:4: externally_used: Not detected
+./examples/using_dune/reduced_lib/values.mli:8: lib_internal_internally_used
+./examples/using_dune/reduced_lib/values.mli:9: lib_internal_externally_used
+./examples/using_dune/reduced_lib/values_in_submodules.mli:3: Exported.used_by_API
+./examples/using_dune/reduced_lib/values_in_submodules.mli:5: Exported.externally_used: Not detected
+./examples/using_dune/reduced_lib/values_in_submodules.mli:9: Exported.lib_internal_internally_used
+./examples/using_dune/reduced_lib/values_in_submodules.mli:10: Exported.lib_internal_externally_used
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:3: Exported.used_by_API
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:5: Exported.externally_used: Not detected
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:9: Exported.lib_internal_internally_used
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:10: Exported.lib_internal_externally_used
+./examples/using_dune/reduced_lib/values_no_intf.ml:2: used_by_API
+./examples/using_dune/reduced_lib/values_no_intf.ml:4: externally_used: Not detected
+./examples/using_dune/reduced_lib/values_no_intf.ml:12: lib_internal_internally_used
+./examples/using_dune/reduced_lib/values_no_intf.ml:13: lib_internal_externally_used
 
 ./examples/using_dune/unwrapped_lib/opt_args/opt_args.mli:8: internally_used_fun_with_single_never_used_opt_arg
 ./examples/using_dune/unwrapped_lib/opt_args/opt_args.mli:10: internally_used_fun_with_single_always_used_opt_arg
@@ -252,6 +296,23 @@
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:59: internally_used_f
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:64: externally_used_f
 
+./examples/using_dune/reduced_lib/values.mli:1: used: Not detected
+./examples/using_dune/reduced_lib/values.mli:3: internally_used
+./examples/using_dune/reduced_lib/values.mli:4: externally_used: Should not be detected
+./examples/using_dune/reduced_lib/values.mli:6: lib_internal_used
+./examples/using_dune/reduced_lib/values_in_submodules.mli:2: Exported.used: Not detected
+./examples/using_dune/reduced_lib/values_in_submodules.mli:4: Exported.internally_used
+./examples/using_dune/reduced_lib/values_in_submodules.mli:5: Exported.externally_used: Should not be detected
+./examples/using_dune/reduced_lib/values_in_submodules.mli:7: Exported.lib_internal_used
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:2: Exported.used: Not detected
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:4: Exported.internally_used
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:5: Exported.externally_used: Should not be detected
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:7: Exported.lib_internal_used
+./examples/using_dune/reduced_lib/values_no_intf.ml:1: used: Not detected
+./examples/using_dune/reduced_lib/values_no_intf.ml:3: internally_used
+./examples/using_dune/reduced_lib/values_no_intf.ml:4: externally_used: Should not be detected
+./examples/using_dune/reduced_lib/values_no_intf.ml:10: lib_internal_used
+
 ./examples/using_dune/unwrapped_lib/obj/with_class.mli:33: fun_class_factory
 
 ./examples/using_dune/unwrapped_lib/opt_args/opt_args.mli:2: used_fun_with_single_explicitly_discarded_opt_arg
@@ -335,6 +396,10 @@
 
 .>->  ALMOST UNUSED EXPORTED VALUES: Called 3 time(s):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+./examples/using_dune/reduced_lib/values.mli:1: used: Should not be detected
+./examples/using_dune/reduced_lib/values_in_submodules.mli:2: Exported.used: Should not be detected
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:2: Exported.used: Should not be detected
+./examples/using_dune/reduced_lib/values_no_intf.ml:1: used: Should not be detected
 ./examples/using_dune/unwrapped_lib/values/values_no_intf.ml:19: aliased_fun
 
 ./examples/using_dune/wrapped_lib/values/values_no_intf.ml:19: aliased_fun
@@ -1198,7 +1263,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 1018
-Success: 1018
-Failed: 0
-Ratio: 100.%
+Total: 1079
+Success: 1063
+Failed: 16
+Ratio: 98.5171455051%

--- a/check/threshold-3-0.5/threshold-3-0.5.ref
+++ b/check/threshold-3-0.5/threshold-3-0.5.ref
@@ -140,19 +140,19 @@
 ./examples/using_dune/reduced_lib/reduced_lib.mli:26: Values_in_submodules_no_intf.Exported.used
 ./examples/using_dune/reduced_lib/reduced_lib.mli:29: Values_in_submodules_no_intf.Exported.externally_used
 ./examples/using_dune/reduced_lib/values.mli:2: used_by_API
-./examples/using_dune/reduced_lib/values.mli:4: externally_used: Not detected
+./examples/using_dune/reduced_lib/values.mli:4: externally_used
 ./examples/using_dune/reduced_lib/values.mli:8: lib_internal_internally_used
 ./examples/using_dune/reduced_lib/values.mli:9: lib_internal_externally_used
 ./examples/using_dune/reduced_lib/values_in_submodules.mli:3: Exported.used_by_API
-./examples/using_dune/reduced_lib/values_in_submodules.mli:5: Exported.externally_used: Not detected
+./examples/using_dune/reduced_lib/values_in_submodules.mli:5: Exported.externally_used
 ./examples/using_dune/reduced_lib/values_in_submodules.mli:9: Exported.lib_internal_internally_used
 ./examples/using_dune/reduced_lib/values_in_submodules.mli:10: Exported.lib_internal_externally_used
 ./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:3: Exported.used_by_API
-./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:5: Exported.externally_used: Not detected
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:5: Exported.externally_used
 ./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:9: Exported.lib_internal_internally_used
 ./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:10: Exported.lib_internal_externally_used
 ./examples/using_dune/reduced_lib/values_no_intf.ml:2: used_by_API
-./examples/using_dune/reduced_lib/values_no_intf.ml:4: externally_used: Not detected
+./examples/using_dune/reduced_lib/values_no_intf.ml:4: externally_used
 ./examples/using_dune/reduced_lib/values_no_intf.ml:12: lib_internal_internally_used
 ./examples/using_dune/reduced_lib/values_no_intf.ml:13: lib_internal_externally_used
 
@@ -296,21 +296,17 @@
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:59: internally_used_f
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:64: externally_used_f
 
-./examples/using_dune/reduced_lib/values.mli:1: used: Not detected
+./examples/using_dune/reduced_lib/values.mli:1: used
 ./examples/using_dune/reduced_lib/values.mli:3: internally_used
-./examples/using_dune/reduced_lib/values.mli:4: externally_used: Should not be detected
 ./examples/using_dune/reduced_lib/values.mli:6: lib_internal_used
-./examples/using_dune/reduced_lib/values_in_submodules.mli:2: Exported.used: Not detected
+./examples/using_dune/reduced_lib/values_in_submodules.mli:2: Exported.used
 ./examples/using_dune/reduced_lib/values_in_submodules.mli:4: Exported.internally_used
-./examples/using_dune/reduced_lib/values_in_submodules.mli:5: Exported.externally_used: Should not be detected
 ./examples/using_dune/reduced_lib/values_in_submodules.mli:7: Exported.lib_internal_used
-./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:2: Exported.used: Not detected
+./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:2: Exported.used
 ./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:4: Exported.internally_used
-./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:5: Exported.externally_used: Should not be detected
 ./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:7: Exported.lib_internal_used
-./examples/using_dune/reduced_lib/values_no_intf.ml:1: used: Not detected
+./examples/using_dune/reduced_lib/values_no_intf.ml:1: used
 ./examples/using_dune/reduced_lib/values_no_intf.ml:3: internally_used
-./examples/using_dune/reduced_lib/values_no_intf.ml:4: externally_used: Should not be detected
 ./examples/using_dune/reduced_lib/values_no_intf.ml:10: lib_internal_used
 
 ./examples/using_dune/unwrapped_lib/obj/with_class.mli:33: fun_class_factory
@@ -396,10 +392,6 @@
 
 .>->  ALMOST UNUSED EXPORTED VALUES: Called 3 time(s):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-./examples/using_dune/reduced_lib/values.mli:1: used: Should not be detected
-./examples/using_dune/reduced_lib/values_in_submodules.mli:2: Exported.used: Should not be detected
-./examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml:2: Exported.used: Should not be detected
-./examples/using_dune/reduced_lib/values_no_intf.ml:1: used: Should not be detected
 ./examples/using_dune/unwrapped_lib/values/values_no_intf.ml:19: aliased_fun
 
 ./examples/using_dune/wrapped_lib/values/values_no_intf.ml:19: aliased_fun
@@ -1263,7 +1255,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 1079
-Success: 1063
-Failed: 16
-Ratio: 98.5171455051%
+Total: 1071
+Success: 1071
+Failed: 0
+Ratio: 100.%

--- a/examples/using_dune/bin/dune
+++ b/examples/using_dune/bin/dune
@@ -1,3 +1,6 @@
 (executable
  (name using_dune)
- (libraries use_unwrapped_lib use_wrapped_lib use_preprocessed_lib))
+ (libraries use_unwrapped_lib
+            use_wrapped_lib
+            use_preprocessed_lib
+            use_reduced_lib))

--- a/examples/using_dune/bin/use_preprocessed_lib/dune
+++ b/examples/using_dune/bin/use_preprocessed_lib/dune
@@ -1,4 +1,3 @@
 (library
  (name use_preprocessed_lib)
- (libraries preprocessed_lib)
- (wrapped false))
+ (libraries preprocessed_lib))

--- a/examples/using_dune/bin/use_reduced_lib/dune
+++ b/examples/using_dune/bin/use_reduced_lib/dune
@@ -1,0 +1,3 @@
+(library
+ (name use_reduced_lib)
+ (libraries reduced_lib))

--- a/examples/using_dune/bin/use_reduced_lib/use_reduced_lib.ml
+++ b/examples/using_dune/bin/use_reduced_lib/use_reduced_lib.ml
@@ -1,0 +1,9 @@
+let () =
+  Use_values.mark_used ();
+  Use_values_no_intf.mark_used ();
+  Use_values_in_submodules.mark_used ();
+  Use_values_in_submodules_no_intf.mark_used ()
+
+let is_used = ref false
+let mark_used () =
+  is_used := true

--- a/examples/using_dune/bin/use_reduced_lib/use_reduced_lib.mli
+++ b/examples/using_dune/bin/use_reduced_lib/use_reduced_lib.mli
@@ -1,0 +1,2 @@
+val mark_used : unit -> unit
+

--- a/examples/using_dune/bin/use_reduced_lib/use_values.ml
+++ b/examples/using_dune/bin/use_reduced_lib/use_values.ml
@@ -1,0 +1,8 @@
+(* extenal uses with explicit module *)
+let () =
+  ignore Reduced_lib.Values.used;
+  ignore Reduced_lib.Values.externally_used
+
+let is_used = ref false
+let mark_used () =
+  is_used := true

--- a/examples/using_dune/bin/use_reduced_lib/use_values.mli
+++ b/examples/using_dune/bin/use_reduced_lib/use_values.mli
@@ -1,0 +1,1 @@
+val mark_used : unit -> unit

--- a/examples/using_dune/bin/use_reduced_lib/use_values_in_submodules.ml
+++ b/examples/using_dune/bin/use_reduced_lib/use_values_in_submodules.ml
@@ -1,0 +1,8 @@
+(* extenal uses with explicit module *)
+let () =
+  ignore Reduced_lib.Values_in_submodules.Exported.used;
+  ignore Reduced_lib.Values_in_submodules.Exported.externally_used
+
+let is_used = ref false
+let mark_used () =
+  is_used := true

--- a/examples/using_dune/bin/use_reduced_lib/use_values_in_submodules.mli
+++ b/examples/using_dune/bin/use_reduced_lib/use_values_in_submodules.mli
@@ -1,0 +1,1 @@
+val mark_used : unit -> unit

--- a/examples/using_dune/bin/use_reduced_lib/use_values_in_submodules_no_intf.ml
+++ b/examples/using_dune/bin/use_reduced_lib/use_values_in_submodules_no_intf.ml
@@ -1,0 +1,8 @@
+(* extenal uses with explicit module *)
+let () =
+  ignore Reduced_lib.Values_in_submodules_no_intf.Exported.used;
+  ignore Reduced_lib.Values_in_submodules_no_intf.Exported.externally_used
+
+let is_used = ref false
+let mark_used () =
+  is_used := true

--- a/examples/using_dune/bin/use_reduced_lib/use_values_in_submodules_no_intf.mli
+++ b/examples/using_dune/bin/use_reduced_lib/use_values_in_submodules_no_intf.mli
@@ -1,0 +1,1 @@
+val mark_used : unit -> unit

--- a/examples/using_dune/bin/use_reduced_lib/use_values_no_intf.ml
+++ b/examples/using_dune/bin/use_reduced_lib/use_values_no_intf.ml
@@ -1,0 +1,8 @@
+(* extenal uses with explicit module *)
+let () =
+  ignore Reduced_lib.Values_no_intf.used;
+  ignore Reduced_lib.Values_no_intf.externally_used
+
+let is_used = ref false
+let mark_used () =
+  is_used := true

--- a/examples/using_dune/bin/use_reduced_lib/use_values_no_intf.mli
+++ b/examples/using_dune/bin/use_reduced_lib/use_values_no_intf.mli
@@ -1,0 +1,1 @@
+val mark_used : unit -> unit

--- a/examples/using_dune/bin/use_unwrapped_lib/dune
+++ b/examples/using_dune/bin/use_unwrapped_lib/dune
@@ -1,4 +1,3 @@
 (library
  (name use_unwrapped_lib)
- (libraries unwrapped_lib)
- (wrapped false))
+ (libraries unwrapped_lib))

--- a/examples/using_dune/bin/use_wrapped_lib/dune
+++ b/examples/using_dune/bin/use_wrapped_lib/dune
@@ -1,4 +1,3 @@
 (library
  (name use_wrapped_lib)
- (libraries wrapped_lib)
- (wrapped true))
+ (libraries wrapped_lib))

--- a/examples/using_dune/bin/using_dune.ml
+++ b/examples/using_dune/bin/using_dune.ml
@@ -1,4 +1,5 @@
 let () =
   Use_unwrapped_lib.mark_used ();
   Use_wrapped_lib.mark_used ();
-  Use_preprocessed_lib.mark_used ()
+  Use_preprocessed_lib.mark_used ();
+  Use_reduced_lib.mark_used ()

--- a/examples/using_dune/reduced_lib/README.md
+++ b/examples/using_dune/reduced_lib/README.md
@@ -1,0 +1,33 @@
+This library is used to test 2 things :
+1. That values defined in the library's submodules and not exposed in the
+   library's API are tracked correctly and reported at locations in
+   the submodules
+2. That values defined in the library's submodules and those exposed in the
+   library's API are "decoupled" :
+    - If a value is unused outside the library, then it is reported at a
+      location in the library's interface (and not the submodule's).
+    - The submodules' values are "used by the type" of the library. I.e. because
+      the library expose them in its API, then they must exist in the
+      submodules. Thus, they are used by the API's requirements and must not be
+      reported as unused.
+
+The intent is to avoid duplicated reports and provide actually actionable
+results.
+E.g. Instead of
+```
+some_lib.mli:12: Foo.x
+foo.mli:3: x
+```
+only report
+```
+some_lib.mli:12: Foo.x
+```
+Once `Some_lib.Foo.x` is removed from `Some_lib`'s API, a new run of the
+`dead_code_analyzer` would be able to report
+```
+foo.mli:3: x
+```
+
+In this library's submodules, the values prefixed by `lib_internal` are not
+exposed by the API but still exported by the submodules. All the other exported
+values are re-exposed in `Reduced_lib`'s API.

--- a/examples/using_dune/reduced_lib/dune
+++ b/examples/using_dune/reduced_lib/dune
@@ -1,0 +1,4 @@
+(library
+ (name reduced_lib)
+ (flags (:standard -warn-error -A))
+ (wrapped true))

--- a/examples/using_dune/reduced_lib/reduced_lib.ml
+++ b/examples/using_dune/reduced_lib/reduced_lib.ml
@@ -1,0 +1,14 @@
+module Values = Values
+module Values_no_intf = Values_no_intf
+module Values_in_submodules = Values_in_submodules
+module Values_in_submodules_no_intf = Values_in_submodules_no_intf
+
+let () =
+  ignore Values.lib_internal_used;
+  ignore Values.lib_internal_externally_used;
+  ignore Values_no_intf.lib_internal_used;
+  ignore Values_no_intf.lib_internal_externally_used;
+  ignore Values_in_submodules.Exported.lib_internal_used;
+  ignore Values_in_submodules.Exported.lib_internal_externally_used;
+  ignore Values_in_submodules_no_intf.Exported.lib_internal_used;
+  ignore Values_in_submodules_no_intf.Exported.lib_internal_externally_used

--- a/examples/using_dune/reduced_lib/reduced_lib.mli
+++ b/examples/using_dune/reduced_lib/reduced_lib.mli
@@ -1,0 +1,31 @@
+module Values : sig
+  val used : int
+  val used_by_API : int
+  val internally_used : int
+  val externally_used : int
+end
+
+module Values_no_intf : sig
+  val used : int
+  val used_by_API : int
+  val internally_used : int
+  val externally_used : int
+end
+
+module Values_in_submodules : sig
+  module Exported : sig
+    val used : int
+    val used_by_API : int
+    val internally_used : int
+    val externally_used : int
+  end
+end
+
+module Values_in_submodules_no_intf : sig
+  module Exported : sig
+    val used : int
+    val used_by_API : int
+    val internally_used : int
+    val externally_used : int
+  end
+end

--- a/examples/using_dune/reduced_lib/values.ml
+++ b/examples/using_dune/reduced_lib/values.ml
@@ -1,0 +1,17 @@
+let used = 42
+let used_by_API = 42
+let internally_used = 42
+let externally_used = 42
+
+let () =
+  ignore used;
+  ignore internally_used
+
+let lib_internal_used = 42
+let lib_internal_unused = 42
+let lib_internal_internally_used = 42
+let lib_internal_externally_used = 42
+
+let () =
+  ignore lib_internal_used;
+  ignore lib_internal_internally_used

--- a/examples/using_dune/reduced_lib/values.mli
+++ b/examples/using_dune/reduced_lib/values.mli
@@ -1,0 +1,9 @@
+val used : int
+val used_by_API : int
+val internally_used : int
+val externally_used : int
+
+val lib_internal_used : int
+val lib_internal_unused : int
+val lib_internal_internally_used : int
+val lib_internal_externally_used : int

--- a/examples/using_dune/reduced_lib/values_in_submodules.ml
+++ b/examples/using_dune/reduced_lib/values_in_submodules.ml
@@ -1,0 +1,34 @@
+module Unexported = struct
+  let used = 42
+  let unused = 42
+end
+
+module Exported = struct
+  module Private = struct
+    let used = 42
+    let unused = 42
+  end
+
+  let used = 42
+  let used_by_API = 42
+  let internally_used = 42
+  let externally_used = 42
+
+  let lib_internal_used = 42
+  let lib_internal_unused = 42
+  let lib_internal_internally_used = 42
+  let lib_internal_externally_used = 42
+
+end
+
+let () = ignore Unexported.used
+
+let () = ignore Exported.Private.used
+
+let () =
+  ignore Exported.used;
+  ignore Exported.internally_used
+
+let () =
+  ignore Exported.lib_internal_used;
+  ignore Exported.lib_internal_internally_used

--- a/examples/using_dune/reduced_lib/values_in_submodules.mli
+++ b/examples/using_dune/reduced_lib/values_in_submodules.mli
@@ -1,0 +1,11 @@
+module Exported : sig
+  val used : int
+  val used_by_API : int
+  val internally_used : int
+  val externally_used : int
+
+  val lib_internal_used : int
+  val lib_internal_unused : int
+  val lib_internal_internally_used : int
+  val lib_internal_externally_used : int
+end

--- a/examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml
+++ b/examples/using_dune/reduced_lib/values_in_submodules_no_intf.ml
@@ -1,0 +1,20 @@
+module Exported = struct
+  let used = 42
+  let used_by_API = 42
+  let internally_used = 42
+  let externally_used = 42
+
+  let lib_internal_used = 42
+  let lib_internal_unused = 42
+  let lib_internal_internally_used = 42
+  let lib_internal_externally_used = 42
+
+end
+
+let () =
+  ignore Exported.used;
+  ignore Exported.internally_used
+
+let () =
+  ignore Exported.lib_internal_used;
+  ignore Exported.lib_internal_internally_used

--- a/examples/using_dune/reduced_lib/values_no_intf.ml
+++ b/examples/using_dune/reduced_lib/values_no_intf.ml
@@ -1,0 +1,17 @@
+let used = 42
+let used_by_API = 42
+let internally_used = 42
+let externally_used = 42
+
+let () =
+  ignore used;
+  ignore internally_used
+
+let lib_internal_used = 42
+let lib_internal_unused = 42
+let lib_internal_internally_used = 42
+let lib_internal_externally_used = 42
+
+let () =
+  ignore lib_internal_used;
+  ignore lib_internal_internally_used

--- a/src/deadCode.ml
+++ b/src/deadCode.ml
@@ -400,9 +400,10 @@ let assoc decs (loc1, loc2) =
     if (!DeadFlag.internal || fn1 <> fn2) && is_implem fn1 && is_implem fn2 then
       DeadCommon.LocHash.merge_set references loc2 references loc1;
     if is_iface fn1 loc1 then begin
-      DeadCommon.LocHash.merge_set references loc1 references loc2;
       if is_iface fn2 loc2 then
         DeadCommon.LocHash.add_set references loc1 loc2
+      else
+        DeadCommon.LocHash.merge_set references loc1 references loc2;
     end
     else
       DeadCommon.LocHash.merge_set references loc2 references loc1


### PR DESCRIPTION
When designing a lib, one may want to explictly expose some submodules as part of its API. While doing so, some parts of these submodules may remain hidden from the API but exposed by the submodules for internal use.
Reporting on values in a library API and submodules must remain actionable. Therefore, the semantic is:
- For a value defined in the submodule, account for all the uses internal to the library but the ones in the submodule itself (unless there is no interface or the `--internal` option is used, as usual). Among those uses, re-expositions count. I.e. if the value is exposed by the API, then this counts as a use because it is required.
- For a submodule's value exposed in the API, account for all the uses external to the library.

Uses of an API value is not be propagated to the submodule's value. Only the re-exposition counts as a use.
Hence, a submodule's value explicitly exposed in the API cannot be reported as unused while the API's value may be.

This is coherent with the general value reporting semantic.