### PR TITLE
Refactor cli internals

### DIFF
--- a/src/config/config.ml
+++ b/src/config/config.ml
@@ -33,6 +33,14 @@ let config = ref
   ; sections = Sections.default
   }
 
+let has_main_section_activated () =
+  let sections = !config.sections in
+  has_activated [sections.exported_values; sections.methods; sections.types]
+
+let has_opt_args_section_activated () =
+  let sections = !config.sections in
+  has_activated [sections.opta; sections.optn]
+
 let update_exported_values arg =
   let sections = Sections.update_exported_values arg !config.sections in
   config := {!config with sections}

--- a/src/config/config.ml
+++ b/src/config/config.ml
@@ -7,10 +7,10 @@
 (*                                                                         *)
 (***************************************************************************)
 
-type threshold = {exceptions: int; percentage: float; optional: [`Percent | `Both]}
+type threshold = {percentage: float; exceptions: int; optional: [`Percent | `Both]}
 
 
-type opt = {print: bool; call_sites: bool; threshold: threshold}
+type opt = {print: bool; threshold: threshold; call_sites: bool}
 let opta = ref
   {
     print = false;
@@ -121,7 +121,7 @@ let update_style s =
   aux (list_of_opt s)
 
 
-type basic = {print: bool; call_sites: bool; threshold: int}
+type basic = {print: bool; threshold: int; call_sites: bool}
 let exported : basic ref = ref
   ({
     print = true;

--- a/src/config/config.ml
+++ b/src/config/config.ml
@@ -212,3 +212,86 @@ let exclude, is_excluded =
   let exclude s = Hashtbl.replace tbl (normalize_path s) () in
   let is_excluded s = Hashtbl.mem tbl (normalize_path s) in
   exclude, is_excluded
+
+
+(* Option parsing and processing *)
+let parse_cli process_path =
+  let update_all print () =
+    update_style ((if print = "all" then "+" else "-") ^ "all");
+    update_main "-E" config.exported print;
+    update_main "-M" config.obj print;
+    update_main "-T" config.typ print;
+    update_opt config.opta print;
+    update_opt config.optn print
+  in
+
+  (* any extra argument can be accepted by any option using some
+   * although it doesn't necessary affects the results (e.g. -O 3+4) *)
+  Arg.(parse
+    [ "--exclude", String exclude, "<path>  Exclude given path from research.";
+
+      "--references",
+        String (fun dir -> config.directories <- dir :: config.directories),
+        "<path>  Consider given path to collect references.";
+
+      "--underscore", Unit set_underscore, " Show names starting with an underscore";
+
+      "--verbose", Unit set_verbose, " Verbose mode (ie., show scanned files)";
+      "-v", Unit set_verbose, " See --verbose";
+
+      "--internal", Unit set_internal,
+        " Keep internal uses as exported values uses when the interface is given. \
+          This is the default behaviour when only the implementation is found";
+
+      "--nothing", Unit (update_all "nothing"), " Disable all warnings";
+      "-a", Unit (update_all "nothing"), " See --nothing";
+      "--all", Unit (update_all "all"), " Enable all warnings";
+      "-A", Unit (update_all "all"), " See --all";
+
+      "-E", String (update_main "-E" config.exported),
+        "<display>  Enable/Disable unused exported values warnings.\n    \
+        <display> can be:\n\
+          \tall\n\
+          \tnothing\n\
+          \t\"threshold:<integer>\": report elements used up to the given integer\n\
+          \t\"calls:<integer>\": like threshold + show call sites";
+
+      "-M", String (update_main "-M" config.obj),
+        "<display>  Enable/Disable unused methods warnings.\n    \
+        See option -E for the syntax of <display>";
+
+      "-Oa", String (update_opt config.opta),
+        "<display>  Enable/Disable optional arguments always used warnings.\n    \
+        <display> can be:\n\
+          \tall\n\
+          \tnothing\n\
+          \t<threshold>\n\
+          \t\"calls:<threshold>\" like <threshold> + show call sites\n    \
+        <threshold> can be:\n\
+          \t\"both:<integer>,<float>\": both the number max of exceptions \
+          (given through the integer) and the percent of valid cases (given as a float) \
+          must be respected for the element to be reported\n\
+          \t\"percent:<float>\": percent of valid cases to be reported";
+
+      "-On", String (update_opt config.optn),
+        "<display>  Enable/Disable optional arguments never used warnings.\n    \
+        See option -Oa for the syntax of <display>";
+
+      "-S", String (update_style),
+        " Enable/Disable coding style warnings.\n    \
+        Delimiters '+' and '-' determine if the following option is to enable or disable.\n    \
+        Options (can be used together):\n\
+          \tbind: useless binding\n\
+          \topt: optional arg in arg\n\
+          \tseq: use sequence\n\
+          \tunit: unit pattern\n\
+          \tall: bind & opt & seq & unit";
+
+      "-T", String (update_main "-T" config.typ),
+        "<display>  Enable/Disable unused constructors/records fields warnings.\n    \
+        See option -E for the syntax of <display>";
+
+    ]
+    (Printf.eprintf "Scanning files...\n%!";
+     process_path)
+    ("Usage: " ^ Sys.argv.(0) ^ " <options> <path>\nOptions are:"))

--- a/src/config/config.ml
+++ b/src/config/config.ml
@@ -7,48 +7,22 @@
 (*                                                                         *)
 (***************************************************************************)
 
-type 'threshold section =
-  | Off
-  | On
-  | Threshold of 'threshold threshold_section
+module Sections = Sections
 
-and 'threshold threshold_section =
-  { threshold: 'threshold
-  ; call_sites: bool
-  }
+let is_activated = Sections.is_activated
 
-let is_activated = function
-  | Off -> false
-  | _ -> true
+let has_activated = Sections.has_activated
 
-let has_activated l = List.exists is_activated l
+let call_sites_activated = Sections.call_sites_activated
 
-let call_sites_activated = function
-  | Threshold {call_sites; _} -> call_sites
-  | _ -> false
-
-
-type main_section = int section
-
-type opt_threshold =
-  | Percent of float
-  | Both of (int * float)
-
-type opt_section = opt_threshold section
-
-type style = {opt_arg: bool; unit_pat: bool; seq: bool; binding: bool}
+let get_main_threshold = Sections.get_main_threshold
 
 type t =
   { verbose : bool
   ; internal : bool
   ; underscore : bool
   ; directories : string list
-  ; exported : main_section
-  ; obj : main_section
-  ; typ : main_section
-  ; opta : opt_section
-  ; optn : opt_section
-  ; style : style
+  ; sections : Sections.t
   }
 
 let config = ref
@@ -56,156 +30,32 @@ let config = ref
   ; internal = false
   ; underscore = false
   ; directories = []
-  ; exported = On
-  ; obj = On
-  ; typ = On
-  ; opta = Off
-  ; optn = Off
-  ; style =
-      { opt_arg = false
-      ; unit_pat = false
-      ; seq = false
-      ; binding = false
-      }
+  ; sections = Sections.default
   }
 
-let get_main_threshold = function
-  | Threshold {threshold; _} -> threshold
-  | _ -> 0
+let update_exported_values arg =
+  let sections = Sections.update_exported_values arg !config.sections in
+  config := {!config with sections}
 
-let parse_main opt = function
-    | "all" -> On
-    | "nothing" -> Off
-    | arg ->
-        let raise_bad_arg msg =
-          raise (Arg.Bad (opt ^ ": " ^ msg))
-        in
-        let threshold_section =
-          let call_sites, threshold =
-            let len = String.length arg in
-            if String.starts_with ~prefix:"calls:" arg then
-              (true, String.sub arg 6 (len - 6))
-            else if String.starts_with ~prefix:"threshold:" arg then
-              (false, String.sub arg 10 (len - 10))
-            else raise_bad_arg ("unknown option: " ^ arg)
-          in
-          match String.trim threshold |> int_of_string with
-          | exception Failure _ ->
-              raise_bad_arg ("expected an integer; got; Got " ^ threshold)
-          | n when n < 0 ->
-              raise_bad_arg ("integer should be >= 0; Got " ^ string_of_int n)
-          | threshold -> {threshold; call_sites}
-        in
-        Threshold threshold_section
+let update_methods arg =
+  let sections = Sections.update_methods arg !config.sections in
+  config := {!config with sections}
 
-let update_exported cli_opt arg =
-  let exported = parse_main cli_opt arg in
-  config := {!config with exported}
-
-let update_obj cli_opt arg =
-  let obj = parse_main cli_opt arg in
-  config := {!config with obj}
-
-let update_typ cli_opt arg =
-  let typ = parse_main cli_opt arg in
-  config := {!config with typ}
-
-
-let parse_opt = function
-  | "all" -> On
-  | "nothing" -> Off
-  | arg ->
-      let raise_bad_arg msg =
-        (* TODO: improve error reporting *)
-        raise (Arg.Bad ("-Ox: " ^ msg))
-      in
-      let call_sites, arg =
-        if String.starts_with ~prefix:"calls" arg then
-          let arg = String.sub arg 6 (String.length arg - 6) in
-          (true, arg)
-        else (false, arg)
-      in
-      let check_percentage p =
-        if p > 1. || p < 0. then
-          raise_bad_arg "percentage must be >= 0.0 and <= 1.0"
-      in
-      let check_nb_exceptions n =
-        if n < 0 then raise_bad_arg "number of exceptions must be >= 0"
-      in
-      let threshold =
-        let len = String.length arg in
-        if String.starts_with ~prefix:"both:" arg then
-          let limits = String.sub arg 5 (len - 5) in
-          match Scanf.sscanf limits "%u , %F" (fun i f -> (i, f)) with
-          | exception Scanf.Scan_failure _
-          | exception Failure _
-          | exception End_of_file ->
-              (* TODO: improve error handling/reporting *)
-              raise_bad_arg ("wrong arguments: " ^ limits)
-          | (nb_exceptions, percentage) as limits ->
-              check_percentage percentage;
-              check_nb_exceptions nb_exceptions;
-              Both limits
-        else if String.starts_with ~prefix:"percent:" arg then
-          let percentage = String.sub arg 8 (len - 8) |> String.trim in
-          match float_of_string percentage with
-          | exception Failure _ ->
-              (* TODO: improve error handling/reporting *)
-              raise_bad_arg ("wrong argument: " ^ percentage)
-          | percentage ->
-              check_percentage percentage;
-              Percent percentage
-        else raise_bad_arg ("unknown option " ^ arg)
-      in
-      Threshold {threshold; call_sites}
+let update_types arg =
+  let sections = Sections.update_types arg !config.sections in
+  config := {!config with sections}
 
 let update_opta arg =
-  let opta = parse_opt arg in
-  config := {!config with opta}
+  let sections = Sections.update_opta arg !config.sections in
+  config := {!config with sections}
 
 let update_optn arg =
-  let optn = parse_opt arg in
-  config := {!config with optn}
+  let sections = Sections.update_optn arg !config.sections in
+  config := {!config with sections}
 
-
-let update_style s =
-  let rec aux = function
-    | (b, "opt")::l ->
-        let style = {!config.style with opt_arg = b} in
-        config := {!config with style};
-        aux l
-    | (b, "unit")::l ->
-        let style = {!config.style with unit_pat = b} in
-        config := {!config with style};
-        aux l
-    | (b, "seq")::l ->
-        let style = {!config.style with seq = b} in
-        config := {!config with style};
-        aux l
-    | (b, "bind")::l ->
-        let style = {!config.style with binding = b} in
-        config := {!config with style};
-        aux l
-    | (b, "all")::l ->
-        let style = {unit_pat = b; opt_arg = b; seq = b; binding = b} in
-        config := {!config with style};
-        aux l
-    | (_, "")::l -> aux l
-    | (_, s)::_ -> raise (Arg.Bad ("-S: unknown option: " ^ s))
-    | [] -> ()
-  in
-  let list_of_opt str =
-    try
-      let rec split acc pos len =
-        if str.[pos] <> '+' && str.[pos] <> '-' then
-          split acc (pos - 1) (len + 1)
-        else let acc = (str.[pos] = '+', String.trim (String.sub str (pos + 1) len)) :: acc in
-          if pos > 0 then split acc (pos - 1) 0
-          else acc
-      in split [] (String.length str - 1) 0
-    with _ -> raise (Arg.Bad ("options' arguments must start with a delimiter (`+' or `-')"))
-  in
-  aux (list_of_opt s)
+let update_style arg =
+  let sections = Sections.update_style arg !config.sections in
+  config := {!config with sections}
 
 let set_verbose () = config := {!config with verbose = true}
 
@@ -247,9 +97,9 @@ let exclude, is_excluded =
 let parse_cli process_path =
   let update_all print () =
     update_style ((if print = "all" then "+" else "-") ^ "all");
-    update_exported "-E" print;
-    update_obj "-M" print;
-    update_typ "-T" print;
+    update_exported_values print;
+    update_methods print;
+    update_types print;
     update_opta print;
     update_optn print
   in
@@ -281,7 +131,7 @@ let parse_cli process_path =
       "--all", Unit (update_all "all"), " Enable all warnings";
       "-A", Unit (update_all "all"), " See --all";
 
-      "-E", String (update_exported "-E"),
+      "-E", String update_exported_values,
         "<display>  Enable/Disable unused exported values warnings.\n    \
         <display> can be:\n\
           \tall\n\
@@ -289,11 +139,11 @@ let parse_cli process_path =
           \t\"threshold:<integer>\": report elements used up to the given integer\n\
           \t\"calls:<integer>\": like threshold + show call sites";
 
-      "-M", String (update_obj "-M"),
+      "-M", String update_methods,
         "<display>  Enable/Disable unused methods warnings.\n    \
         See option -E for the syntax of <display>";
 
-      "-Oa", String (update_opta),
+      "-Oa", String update_opta,
         "<display>  Enable/Disable optional arguments always used warnings.\n    \
         <display> can be:\n\
           \tall\n\
@@ -306,11 +156,11 @@ let parse_cli process_path =
           must be respected for the element to be reported\n\
           \t\"percent:<float>\": percent of valid cases to be reported";
 
-      "-On", String (update_optn),
+      "-On", String update_optn,
         "<display>  Enable/Disable optional arguments never used warnings.\n    \
         See option -Oa for the syntax of <display>";
 
-      "-S", String (update_style),
+      "-S", String update_style,
         " Enable/Disable coding style warnings.\n    \
         Delimiters '+' and '-' determine if the following option is to enable or disable.\n    \
         Options (can be used together):\n\
@@ -320,7 +170,7 @@ let parse_cli process_path =
           \tunit: unit pattern\n\
           \tall: bind & opt & seq & unit";
 
-      "-T", String (update_typ "-T"),
+      "-T", String update_types,
         "<display>  Enable/Disable unused constructors/records fields warnings.\n    \
         See option -E for the syntax of <display>";
 

--- a/src/config/config.mli
+++ b/src/config/config.mli
@@ -19,7 +19,7 @@ val get_main_threshold : Sections.main_section -> int
 
 module StringSet : Set.S with type elt = String.t
 
-type t =
+type t = private
   { verbose : bool (** Display additional information during the analaysis *)
   ; internal : bool (** Keep track of internal uses for exported values *)
   ; underscore : bool (** Keep track of elements with names starting with [_] *)

--- a/src/config/config.mli
+++ b/src/config/config.mli
@@ -27,15 +27,6 @@ val call_sites_activated : _ section -> bool
 
 type main_section = int section
 
-val exported : main_section ref
-(** Configuration for the unused exported values *)
-
-val obj : main_section ref
-(** Configuration for the methods *)
-
-val typ : main_section ref
-(** Configuration for the constructors/record fields *)
-
 val update_main : string -> main_section ref -> string -> unit
 (** [update_basic sec_arg section arg] updates the configuration of [section] according
     to the [arg] specification. [sec_arg] is the command line argument
@@ -57,12 +48,6 @@ type opt_threshold =
 
 type opt_section = opt_threshold section
 
-val opta : opt_section ref
-(** Configuration for the optional arguments always used *)
-
-val optn : opt_section ref
-(** Configuration for the optional arguments never used *)
-
 val update_opt : opt_section ref -> string -> unit
 (** [update_opt section arg] updates the configuration of [section] according
     to the [arg] specification *)
@@ -76,28 +61,37 @@ type style =
   ; binding: bool (** Report [let x = ... in x (=> useless binding)] *)
   }
 
-val style : style ref
-(** Configuration for the stylistic issues *)
 
 val update_style : string -> unit
 (** [update_style arg] updates [!style] according to the [arg] specification *)
 
 (** {2 General configuration} *)
 
-val verbose : bool ref
-(** Display additional information during the analaysis. [false] by default. *)
+type t =
+  { mutable verbose : bool (** Display additional information during the analaysis *)
+  ; mutable internal : bool (** Keep track of internal uses for exported values *)
+  ; mutable underscore : bool (** Keep track of elements with names starting with [_] *)
+  ; mutable directories : string list (** Paths to explore for references only *)
+  ; exported : main_section ref (** Configuration for the unused exported values *)
+  ; obj : main_section ref (** Configuration for the methods *)
+  ; typ : main_section ref (** Configuration for the constructors/record fields *)
+  ; opta : opt_section ref (** Configuration for the optional arguments always used *)
+  ; optn : opt_section ref (** Configuration for the optional arguments never used *)
+  ; style : style ref (** Configuration for the stylistic issues *)
+  }
+
+val config : t
+(** Configuration for the analysis.
+    By default [verbose], [internal], and [underscore] are [false]
+    By default [exported],  [obj], and [typ] are [On].
+    By default [opta], [optn] are [Off].
+    By default all of the fileds in [style] are false. *)
 
 val set_verbose : unit -> unit
 (** Set [verbose] to [true] *)
 
-val underscore : bool ref
-(** Keep track of elements with names starting with [_]. [false] by default. *)
-
 val set_underscore : unit -> unit
 (** Set [underscore] to [true] *)
-
-val internal : bool ref
-(** Keep track of internal uses for exported values. [false] by default. *)
 
 val set_internal : unit -> unit
 (** Set [internal] to [true] *)
@@ -108,6 +102,3 @@ val exclude : string -> unit
 val is_excluded : string -> bool
 (** [is_excluded path] indicates if [path] is excluded from the analysis.
     Excluding a path is done with [exclude path]. *)
-
-val directories : string list ref
-(** Paths to explore for references only *)

--- a/src/config/config.mli
+++ b/src/config/config.mli
@@ -2,32 +2,52 @@
 
 (** {2 Sections configuration} *)
 
-(** {3 Main sections} *)
+type 'threshold section =
+  | Off (** Disabled *)
+  | On (** Enabled *)
+  | Threshold of 'threshold threshold_section (** Enabled with threshold *)
 
-type basic =
-  { print: bool (** Report section *)
-  ; threshold: int
+and 'threshold threshold_section =
+  { threshold: 'threshold
     (** Report subsections for elements used up to [!threshold] *)
   ; call_sites: bool (** Print call sites in the [!threshold]-related subsections *)
   }
 
-val exported : basic ref
+val is_activated : _ section -> bool
+(** [is_activated sec] returns `true` if the section must be reported *)
+
+val has_activated : _ section list -> bool
+(** [has_activated secs] returns `true` if one of the sections must be reported *)
+
+val call_sites_activated : _ section -> bool
+(** [call_sites_activated sec] returns `true` if call sites must be reported in
+    thresholded subsections *)
+
+(** {3 Main sections} *)
+
+type main_section = int section
+
+val exported : main_section ref
 (** Configuration for the unused exported values *)
 
-val obj : basic ref
+val obj : main_section ref
 (** Configuration for the methods *)
 
-val typ : basic ref
+val typ : main_section ref
 (** Configuration for the constructors/record fields *)
 
-val update_basic : string -> basic ref -> string -> unit
+val update_main : string -> main_section ref -> string -> unit
 (** [update_basic sec_arg section arg] updates the configuration of [section] according
     to the [arg] specification. [sec_arg] is the command line argument
     associated with the [section] *)
 
+val get_main_threshold : int section -> int
+(** [get_main_threshold main_sec] returns the threshold if
+    [main_sec = Threshold _], [0] otherwise. *)
+
 (** {3 Optional argument sections} *)
 
-type threshold =
+type opt_threshold =
   { percentage: float
       (** Subsections for opt args always/never used except at most
           [percentage] of the time will be reported *)
@@ -37,20 +57,15 @@ type threshold =
   ; optional: [`Percent | `Both] (** Threshold mode *)
   }
 
-type opt =
-  { print: bool (** Report section *)
-  ; threshold: threshold
-    (** Report subsections for opt args always/never used up to [!threshold] *)
-  ; call_sites: bool (** Print call sites in the [!threshold]-related subsections *)
-  }
+type opt_section = opt_threshold section
 
-val opta : opt ref
+val opta : opt_section ref
 (** Configuration for the optional arguments always used *)
 
-val optn : opt ref
+val optn : opt_section ref
 (** Configuration for the optional arguments never used *)
 
-val update_opt : opt ref -> string -> unit
+val update_opt : opt_section ref -> string -> unit
 (** [update_opt section arg] updates the configuration of [section] according
     to the [arg] specification *)
 

--- a/src/config/config.mli
+++ b/src/config/config.mli
@@ -48,14 +48,12 @@ val get_main_threshold : int section -> int
 (** {3 Optional argument sections} *)
 
 type opt_threshold =
-  { percentage: float
-      (** Subsections for opt args always/never used except at most
-          [percentage] of the time will be reported *)
-  ; exceptions: int
-      (** Only optional arguments always/never used except at most
-          [exceptions] times will be reported in the subsections *)
-  ; optional: [`Percent | `Both] (** Threshold mode *)
-  }
+  | Percent of float
+      (** Subsections for opt args always/never used at least [float] percent of
+      the time will be reported *)
+  | Both of (int * float)
+      (** Subsections for opt args always/never used with at most [int]
+          exceptions and at least [float] percent of the time will be reported *)
 
 type opt_section = opt_threshold section
 

--- a/src/config/config.mli
+++ b/src/config/config.mli
@@ -28,11 +28,17 @@ val update_style : string -> unit
 
 (** {2 General configuration} *)
 
+module StringSet : Set.S with type elt = String.t
+
 type t =
   { verbose : bool (** Display additional information during the analaysis *)
   ; internal : bool (** Keep track of internal uses for exported values *)
   ; underscore : bool (** Keep track of elements with names starting with [_] *)
-  ; directories : string list (** Paths to explore for references only *)
+  ; paths_to_analyze : StringSet.t
+      (** Paths found in the command line and considered for analysis *)
+  ; excluded_paths : StringSet.t
+      (** Paths to exclude from the analysis *)
+  ; references_paths : StringSet.t (** Paths to explore for references only *)
   ; sections : Sections.t (** Config for the different report sections *)
   }
 
@@ -43,7 +49,7 @@ val config : t ref
 
 val is_excluded : string -> bool
 (** [is_excluded path] indicates if [path] is excluded from the analysis.
-    Excluding a path is done with [exclude path]. *)
+    Excluding a path is done with the --exclude command line argument. *)
 
 val parse_cli : (string -> unit)  -> unit
 (** [parse_cli process_path] updates the [config] according to the command line

--- a/src/config/config.mli
+++ b/src/config/config.mli
@@ -27,11 +27,6 @@ val call_sites_activated : _ section -> bool
 
 type main_section = int section
 
-val update_main : string -> main_section ref -> string -> unit
-(** [update_basic sec_arg section arg] updates the configuration of [section] according
-    to the [arg] specification. [sec_arg] is the command line argument
-    associated with the [section] *)
-
 val get_main_threshold : int section -> int
 (** [get_main_threshold main_sec] returns the threshold if
     [main_sec = Threshold _], [0] otherwise. *)
@@ -47,10 +42,6 @@ type opt_threshold =
           exceptions and at least [float] percent of the time will be reported *)
 
 type opt_section = opt_threshold section
-
-val update_opt : opt_section ref -> string -> unit
-(** [update_opt section arg] updates the configuration of [section] according
-    to the [arg] specification *)
 
 (** {3 Stylistic issues section} *)
 
@@ -68,36 +59,24 @@ val update_style : string -> unit
 (** {2 General configuration} *)
 
 type t =
-  { mutable verbose : bool (** Display additional information during the analaysis *)
-  ; mutable internal : bool (** Keep track of internal uses for exported values *)
-  ; mutable underscore : bool (** Keep track of elements with names starting with [_] *)
-  ; mutable directories : string list (** Paths to explore for references only *)
-  ; exported : main_section ref (** Configuration for the unused exported values *)
-  ; obj : main_section ref (** Configuration for the methods *)
-  ; typ : main_section ref (** Configuration for the constructors/record fields *)
-  ; opta : opt_section ref (** Configuration for the optional arguments always used *)
-  ; optn : opt_section ref (** Configuration for the optional arguments never used *)
-  ; style : style ref (** Configuration for the stylistic issues *)
+  { verbose : bool (** Display additional information during the analaysis *)
+  ; internal : bool (** Keep track of internal uses for exported values *)
+  ; underscore : bool (** Keep track of elements with names starting with [_] *)
+  ; directories : string list (** Paths to explore for references only *)
+  ; exported : main_section (** Configuration for the unused exported values *)
+  ; obj : main_section (** Configuration for the methods *)
+  ; typ : main_section (** Configuration for the constructors/record fields *)
+  ; opta : opt_section (** Configuration for the optional arguments always used *)
+  ; optn : opt_section (** Configuration for the optional arguments never used *)
+  ; style : style (** Configuration for the stylistic issues *)
   }
 
-val config : t
+val config : t ref
 (** Configuration for the analysis.
     By default [verbose], [internal], and [underscore] are [false]
     By default [exported],  [obj], and [typ] are [On].
     By default [opta], [optn] are [Off].
     By default all of the fileds in [style] are false. *)
-
-val set_verbose : unit -> unit
-(** Set [verbose] to [true] *)
-
-val set_underscore : unit -> unit
-(** Set [underscore] to [true] *)
-
-val set_internal : unit -> unit
-(** Set [internal] to [true] *)
-
-val exclude : string -> unit
-(** [exclude path] excludse [path] from the analysis *)
 
 val is_excluded : string -> bool
 (** [is_excluded path] indicates if [path] is excluded from the analysis.

--- a/src/config/config.mli
+++ b/src/config/config.mli
@@ -102,3 +102,7 @@ val exclude : string -> unit
 val is_excluded : string -> bool
 (** [is_excluded path] indicates if [path] is excluded from the analysis.
     Excluding a path is done with [exclude path]. *)
+
+val parse_cli : (string -> unit)  -> unit
+(** [parse_cli process_path] updates the [config] according to the command line
+    arguments and processes each input path using [process_path] *)

--- a/src/config/config.mli
+++ b/src/config/config.mli
@@ -7,8 +7,13 @@ module Sections = Sections
 val is_activated : _ Sections.section -> bool
 (** [is_activated sec] returns `true` if the section must be reported *)
 
-val has_activated : _ Sections.section list -> bool
-(** [has_activated secs] returns `true` if one of the sections must be reported *)
+val has_main_section_activated : unit -> bool
+(** [has_main_section_activated ()] indicates if any of the main sections must
+    be reported *)
+
+val has_opt_args_section_activated : unit -> bool
+(** [has_opt_args_section_activated ()] indicates if any of the optional
+    arguments section must be reported *)
 
 val call_sites_activated : _ Sections.section -> bool
 (** [call_sites_activated sec] returns `true` if call sites must be reported in

--- a/src/config/config.mli
+++ b/src/config/config.mli
@@ -4,11 +4,11 @@
 
 module Sections = Sections
 
-val is_activated : _ Sections.section -> bool
-(** [is_activated sec] returns `true` if the section must be reported *)
+val must_report_section : _ Sections.section -> bool
+(** [must_report_section sec] returns `true` if the section must be reported *)
 
-val call_sites_activated : _ Sections.section -> bool
-(** [call_sites_activated sec] returns `true` if call sites must be reported in
+val must_report_call_sites : _ Sections.section -> bool
+(** [must_report_call_sites sec] returns `true` if call sites must be reported in
     thresholded subsections *)
 
 val get_main_threshold : Sections.main_section -> int
@@ -17,36 +17,35 @@ val get_main_threshold : Sections.main_section -> int
 
 (** {2 General configuration} *)
 
-module StringSet : Set.S with type elt = String.t
-
 type t = private
   { verbose : bool (** Display additional information during the analaysis *)
   ; internal : bool (** Keep track of internal uses for exported values *)
   ; underscore : bool (** Keep track of elements with names starting with [_] *)
-  ; paths_to_analyze : StringSet.t
+  ; paths_to_analyze : Utils.StringSet.t
       (** Paths found in the command line and considered for analysis *)
-  ; excluded_paths : StringSet.t
-      (** Paths to exclude from the analysis *)
-  ; references_paths : StringSet.t (** Paths to explore for references only *)
+  ; excluded_paths : Utils.StringSet.t (** Paths to exclude from the analysis *)
+  ; references_paths : Utils.StringSet.t
+      (** Paths to explore for references only *)
   ; sections : Sections.t (** Config for the different report sections *)
   }
 
 val default_config : t
-(** Configuration for the analysis.
+(** Default configuration for the analysis.
     By default [verbose], [internal], and [underscore] are [false]
+    By default [paths_to_analyze], [excluded_paths], and [references_paths] are empty.
     By default [sections] is [Sections.default] *)
 
-val has_main_section_activated : t -> bool
-(** [has_main_section_activated config] indicates if any of the main sections
+val must_report_main : t -> bool
+(** [must_report_main config] indicates if any of the main sections
     is activated in [config] *)
 
-val has_opt_args_section_activated : t -> bool
-(** [has_opt_args_section_activated config] indicates if any of the optional
+val must_report_opt_args : t -> bool
+(** [must_report_opt_args config] indicates if any of the optional
     arguments section is activated in [config] *)
 
 val update_style : string -> t -> t
-(** [update_style arg config] returns a [config] with [style] updated according
-    to the [arg] specification. *)
+(** [update_style arg config] returns a [config] with style section
+    configuration updated according to the [arg] specification. *)
 
 val is_excluded : string -> t -> bool
 (** [is_excluded path config] indicates if [path] is excluded from the analysis

--- a/src/config/config.mli
+++ b/src/config/config.mli
@@ -7,24 +7,13 @@ module Sections = Sections
 val is_activated : _ Sections.section -> bool
 (** [is_activated sec] returns `true` if the section must be reported *)
 
-val has_main_section_activated : unit -> bool
-(** [has_main_section_activated ()] indicates if any of the main sections must
-    be reported *)
-
-val has_opt_args_section_activated : unit -> bool
-(** [has_opt_args_section_activated ()] indicates if any of the optional
-    arguments section must be reported *)
-
 val call_sites_activated : _ Sections.section -> bool
 (** [call_sites_activated sec] returns `true` if call sites must be reported in
     thresholded subsections *)
 
-val get_main_threshold : int Sections.section -> int
+val get_main_threshold : Sections.main_section -> int
 (** [get_main_threshold main_sec] returns the threshold if
     [main_sec = Threshold _], [0] otherwise. *)
-
-val update_style : string -> unit
-(** [update_style arg] updates [!style] according to the [arg] specification *)
 
 (** {2 General configuration} *)
 
@@ -42,15 +31,28 @@ type t =
   ; sections : Sections.t (** Config for the different report sections *)
   }
 
-val config : t ref
+val default_config : t
 (** Configuration for the analysis.
     By default [verbose], [internal], and [underscore] are [false]
     By default [sections] is [Sections.default] *)
 
-val is_excluded : string -> bool
-(** [is_excluded path] indicates if [path] is excluded from the analysis.
+val has_main_section_activated : t -> bool
+(** [has_main_section_activated config] indicates if any of the main sections
+    is activated in [config] *)
+
+val has_opt_args_section_activated : t -> bool
+(** [has_opt_args_section_activated config] indicates if any of the optional
+    arguments section is activated in [config] *)
+
+val update_style : string -> t -> t
+(** [update_style arg config] returns a [config] with [style] updated according
+    to the [arg] specification. *)
+
+val is_excluded : string -> t -> bool
+(** [is_excluded path config] indicates if [path] is excluded from the analysis
+    in [config].
     Excluding a path is done with the --exclude command line argument. *)
 
-val parse_cli : (string -> unit)  -> unit
-(** [parse_cli process_path] updates the [config] according to the command line
-    arguments and processes each input path using [process_path] *)
+val parse_cli : unit -> t
+(** [parse_cli ()] returns a fresh configuration filled up according to the
+    command line arguments *)

--- a/src/config/config.mli
+++ b/src/config/config.mli
@@ -2,56 +2,21 @@
 
 (** {2 Sections configuration} *)
 
-type 'threshold section =
-  | Off (** Disabled *)
-  | On (** Enabled *)
-  | Threshold of 'threshold threshold_section (** Enabled with threshold *)
+module Sections = Sections
 
-and 'threshold threshold_section =
-  { threshold: 'threshold
-    (** Report subsections for elements used up to [!threshold] *)
-  ; call_sites: bool (** Print call sites in the [!threshold]-related subsections *)
-  }
-
-val is_activated : _ section -> bool
+val is_activated : _ Sections.section -> bool
 (** [is_activated sec] returns `true` if the section must be reported *)
 
-val has_activated : _ section list -> bool
+val has_activated : _ Sections.section list -> bool
 (** [has_activated secs] returns `true` if one of the sections must be reported *)
 
-val call_sites_activated : _ section -> bool
+val call_sites_activated : _ Sections.section -> bool
 (** [call_sites_activated sec] returns `true` if call sites must be reported in
     thresholded subsections *)
 
-(** {3 Main sections} *)
-
-type main_section = int section
-
-val get_main_threshold : int section -> int
+val get_main_threshold : int Sections.section -> int
 (** [get_main_threshold main_sec] returns the threshold if
     [main_sec = Threshold _], [0] otherwise. *)
-
-(** {3 Optional argument sections} *)
-
-type opt_threshold =
-  | Percent of float
-      (** Subsections for opt args always/never used at least [float] percent of
-      the time will be reported *)
-  | Both of (int * float)
-      (** Subsections for opt args always/never used with at most [int]
-          exceptions and at least [float] percent of the time will be reported *)
-
-type opt_section = opt_threshold section
-
-(** {3 Stylistic issues section} *)
-
-type style =
-  { opt_arg: bool (** Report [val f : _ -> (... -> (... -> ?_:_ -> ...) -> ...] *)
-  ; unit_pat: bool (** Report unit pattern *)
-  ; seq: bool (** Report [let () = ... in ... (=> use sequence)] *)
-  ; binding: bool (** Report [let x = ... in x (=> useless binding)] *)
-  }
-
 
 val update_style : string -> unit
 (** [update_style arg] updates [!style] according to the [arg] specification *)
@@ -63,20 +28,13 @@ type t =
   ; internal : bool (** Keep track of internal uses for exported values *)
   ; underscore : bool (** Keep track of elements with names starting with [_] *)
   ; directories : string list (** Paths to explore for references only *)
-  ; exported : main_section (** Configuration for the unused exported values *)
-  ; obj : main_section (** Configuration for the methods *)
-  ; typ : main_section (** Configuration for the constructors/record fields *)
-  ; opta : opt_section (** Configuration for the optional arguments always used *)
-  ; optn : opt_section (** Configuration for the optional arguments never used *)
-  ; style : style (** Configuration for the stylistic issues *)
+  ; sections : Sections.t (** Config for the different report sections *)
   }
 
 val config : t ref
 (** Configuration for the analysis.
     By default [verbose], [internal], and [underscore] are [false]
-    By default [exported],  [obj], and [typ] are [On].
-    By default [opta], [optn] are [Off].
-    By default all of the fileds in [style] are false. *)
+    By default [sections] is [Sections.default] *)
 
 val is_excluded : string -> bool
 (** [is_excluded path] indicates if [path] is excluded from the analysis.

--- a/src/config/config.mli
+++ b/src/config/config.mli
@@ -1,0 +1,100 @@
+(** Configuration of the analyzer *)
+
+(** {2 Sections configuration} *)
+
+(** {3 Main sections} *)
+
+type basic =
+  { print: bool (** Report section *)
+  ; threshold: int
+    (** Report subsections for elements used up to [!threshold] *)
+  ; call_sites: bool (** Print call sites in the [!threshold]-related subsections *)
+  }
+
+val exported : basic ref
+(** Configuration for the unused exported values *)
+
+val obj : basic ref
+(** Configuration for the methods *)
+
+val typ : basic ref
+(** Configuration for the constructors/record fields *)
+
+val update_basic : string -> basic ref -> string -> unit
+(** [update_basic sec_arg section arg] updates the configuration of [section] according
+    to the [arg] specification. [sec_arg] is the command line argument
+    associated with the [section] *)
+
+(** {3 Optional argument sections} *)
+
+type threshold =
+  { percentage: float
+      (** Subsections for opt args always/never used except at most
+          [percentage] of the time will be reported *)
+  ; exceptions: int
+      (** Only optional arguments always/never used except at most
+          [exceptions] times will be reported in the subsections *)
+  ; optional: [`Percent | `Both] (** Threshold mode *)
+  }
+
+type opt =
+  { print: bool (** Report section *)
+  ; threshold: threshold
+    (** Report subsections for opt args always/never used up to [!threshold] *)
+  ; call_sites: bool (** Print call sites in the [!threshold]-related subsections *)
+  }
+
+val opta : opt ref
+(** Configuration for the optional arguments always used *)
+
+val optn : opt ref
+(** Configuration for the optional arguments never used *)
+
+val update_opt : opt ref -> string -> unit
+(** [update_opt section arg] updates the configuration of [section] according
+    to the [arg] specification *)
+
+(** {3 Stylistic issues section} *)
+
+type style =
+  { opt_arg: bool (** Report [val f : _ -> (... -> (... -> ?_:_ -> ...) -> ...] *)
+  ; unit_pat: bool (** Report unit pattern *)
+  ; seq: bool (** Report [let () = ... in ... (=> use sequence)] *)
+  ; binding: bool (** Report [let x = ... in x (=> useless binding)] *)
+  }
+
+val style : style ref
+(** Configuration for the stylistic issues *)
+
+val update_style : string -> unit
+(** [update_style arg] updates [!style] according to the [arg] specification *)
+
+(** {2 General configuration} *)
+
+val verbose : bool ref
+(** Display additional information during the analaysis. [false] by default. *)
+
+val set_verbose : unit -> unit
+(** Set [verbose] to [true] *)
+
+val underscore : bool ref
+(** Keep track of elements with names starting with [_]. [false] by default. *)
+
+val set_underscore : unit -> unit
+(** Set [underscore] to [true] *)
+
+val internal : bool ref
+(** Keep track of internal uses for exported values. [false] by default. *)
+
+val set_internal : unit -> unit
+(** Set [internal] to [true] *)
+
+val exclude : string -> unit
+(** [exclude path] excludse [path] from the analysis *)
+
+val is_excluded : string -> bool
+(** [is_excluded path] indicates if [path] is excluded from the analysis.
+    Excluding a path is done with [exclude path]. *)
+
+val directories : string list ref
+(** Paths to explore for references only *)

--- a/src/config/sections.ml
+++ b/src/config/sections.ml
@@ -46,14 +46,14 @@ let default =
     }
   }
 
-let is_activated = function
+let must_report_section = function
   | Off -> false
   | On | Threshold _ -> true
 
 let has_activated l =
-  List.exists is_activated l
+  List.exists must_report_section l
 
-let call_sites_activated = function
+let must_report_call_sites = function
   | Threshold {call_sites; _} -> call_sites
   | On | Off -> false
 
@@ -61,12 +61,12 @@ let get_main_threshold = function
   | Threshold {threshold; _} -> threshold
   | On | Off -> 0
 
-let parse_main_section cli_opt = function
+let parse_main_section main_arg = function
   | "all" -> On
   | "nothing" -> Off
   | arg ->
       let raise_bad_arg msg =
-        raise (Arg.Bad (cli_opt ^ ": " ^ msg))
+        raise (Arg.Bad (main_arg ^ ": " ^ msg))
       in
       let threshold_section =
         let call_sites, threshold =

--- a/src/config/sections.ml
+++ b/src/config/sections.ml
@@ -1,0 +1,195 @@
+type t =
+  { exported_values : main_section
+  ; methods : main_section
+  ; types : main_section
+  ; opta : opt_args_section
+  ; optn : opt_args_section
+  ; style : style_section
+  }
+
+and main_section = int section
+
+and opt_args_section = opt_args_threshold section
+and opt_args_threshold =
+  | Percent of float
+  | Both of (int * float)
+
+and 'threshold section =
+  | Off
+  | On
+  | Threshold of 'threshold thresholded_section
+
+and 'threshold thresholded_section =
+  { threshold: 'threshold
+  ; call_sites: bool
+  }
+
+and style_section =
+  { opt_arg: bool
+  ; unit_pat: bool
+  ; seq: bool
+  ; binding: bool
+  }
+
+
+let default =
+  { exported_values = On
+  ; methods = On
+  ; types = On
+  ; opta = Off
+  ; optn = Off
+  ; style =
+    { opt_arg = false
+    ; unit_pat = false
+    ; seq = false
+    ; binding = false
+    }
+  }
+
+let is_activated = function
+  | Off -> false
+  | On | Threshold _ -> true
+
+let has_activated l =
+  List.exists is_activated l
+
+let call_sites_activated = function
+  | Threshold {call_sites; _} -> call_sites
+  | On | Off -> false
+
+let get_main_threshold = function
+  | Threshold {threshold; _} -> threshold
+  | On | Off -> 0
+
+let parse_main_section cli_opt = function
+  | "all" -> On
+  | "nothing" -> Off
+  | arg ->
+      let raise_bad_arg msg =
+        raise (Arg.Bad (cli_opt ^ ": " ^ msg))
+      in
+      let threshold_section =
+        let call_sites, threshold =
+          let len = String.length arg in
+          if String.starts_with ~prefix:"calls:" arg then
+            (true, String.sub arg 6 (len - 6))
+          else if String.starts_with ~prefix:"threshold:" arg then
+            (false, String.sub arg 10 (len - 10))
+          else raise_bad_arg ("unknown option: " ^ arg)
+        in
+        match String.trim threshold |> int_of_string with
+        | exception Failure _ ->
+            raise_bad_arg ("expected an integer; got; Got " ^ threshold)
+        | n when n < 0 ->
+            raise_bad_arg ("integer should be >= 0; Got " ^ string_of_int n)
+        | threshold -> {threshold; call_sites}
+      in
+      Threshold threshold_section
+
+let update_exported_values arg sections =
+  let exported_values = parse_main_section "-E" arg in
+  {sections with exported_values}
+
+let update_methods arg sections =
+  let methods = parse_main_section "-M" arg in
+  {sections with methods}
+
+let update_types arg sections =
+  let types = parse_main_section "-T" arg in
+  {sections with types}
+
+
+let parse_opt_section = function
+  | "all" -> On
+  | "nothing" -> Off
+  | arg ->
+      let raise_bad_arg msg =
+        (* TODO: improve error reporting *)
+        raise (Arg.Bad ("-Ox: " ^ msg))
+      in
+      let call_sites, arg =
+        if String.starts_with ~prefix:"calls" arg then
+          let arg = String.sub arg 6 (String.length arg - 6) in
+          (true, arg)
+        else (false, arg)
+      in
+      let check_percentage p =
+        if p > 1. || p < 0. then
+          raise_bad_arg "percentage must be >= 0.0 and <= 1.0"
+      in
+      let check_nb_exceptions n =
+        if n < 0 then raise_bad_arg "number of exceptions must be >= 0"
+      in
+      let threshold =
+        let len = String.length arg in
+        if String.starts_with ~prefix:"both:" arg then
+          let limits = String.sub arg 5 (len - 5) in
+          match Scanf.sscanf limits "%u , %F" (fun i f -> (i, f)) with
+          | exception Scanf.Scan_failure _
+          | exception Failure _
+          | exception End_of_file ->
+              (* TODO: improve error handling/reporting *)
+              raise_bad_arg ("wrong arguments: " ^ limits)
+          | (nb_exceptions, percentage) as limits ->
+              check_percentage percentage;
+              check_nb_exceptions nb_exceptions;
+              Both limits
+        else if String.starts_with ~prefix:"percent:" arg then
+          let percentage = String.sub arg 8 (len - 8) |> String.trim in
+          match float_of_string percentage with
+          | exception Failure _ ->
+              (* TODO: improve error handling/reporting *)
+              raise_bad_arg ("wrong argument: " ^ percentage)
+          | percentage ->
+              check_percentage percentage;
+              Percent percentage
+        else raise_bad_arg ("unknown option " ^ arg)
+      in
+      Threshold {threshold; call_sites}
+
+let update_opta arg sections =
+  let opta = parse_opt_section arg in
+  {sections with opta}
+
+let update_optn arg sections =
+  let optn = parse_opt_section arg in
+  {sections with optn}
+
+
+let update_style arg style =
+  let rec aux style = function
+    | (b, "opt")::l ->
+        let style = {style with opt_arg = b} in
+        aux style l
+    | (b, "unit")::l ->
+        let style = {style with unit_pat = b} in
+        aux style l
+    | (b, "seq")::l ->
+        let style = {style with seq = b} in
+        aux style l
+    | (b, "bind")::l ->
+        let style = {style with binding = b} in
+        aux style l
+    | (b, "all")::l ->
+        let style = {unit_pat = b; opt_arg = b; seq = b; binding = b} in
+        aux style l
+    | (_, "")::l -> aux style l
+    | (_, s)::_ -> raise (Arg.Bad ("-S: unknown option: " ^ s))
+    | [] -> style
+  in
+  let list_of_opt arg =
+    try
+      let rec split acc pos len =
+        if arg.[pos] <> '+' && arg.[pos] <> '-' then
+          split acc (pos - 1) (len + 1)
+        else let acc = (arg.[pos] = '+', String.trim (String.sub arg (pos + 1) len)) :: acc in
+          if pos > 0 then split acc (pos - 1) 0
+          else acc
+      in split [] (String.length arg - 1) 0
+    with _ -> raise (Arg.Bad ("options' arguments must start with a delimiter (`+' or `-')"))
+  in
+  aux style (list_of_opt arg)
+
+let update_style arg sections =
+  let style = update_style arg sections.style in
+  {sections with style}

--- a/src/config/sections.mli
+++ b/src/config/sections.mli
@@ -1,4 +1,4 @@
-type t =
+type t = private
   { exported_values : main_section (** Exported values section config *)
   ; methods : main_section (** Methods section config *)
   ; types : main_section (** Constructors/fields section config *)

--- a/src/config/sections.mli
+++ b/src/config/sections.mli
@@ -13,7 +13,7 @@ and opt_args_section = opt_args_threshold section
 and opt_args_threshold =
   | Percent of float
       (** Subsections for opt args always/never used at least [float] percent of
-      the time will be reported *)
+          the time will be reported *)
   | Both of (int * float)
       (** Subsections for opt args always/never used with at most [int]
           exceptions and at least [float] percent of the time will be reported *)
@@ -40,18 +40,19 @@ and style_section =
 
 val default : t
 (** Default sections configuration.
-    [exported],  [obj], and [typ] are [On].
+    [exported_values], [methods], and [types] are [On].
     [opta], [optn] are [Off].
-    All of the fileds in [style] are false. *)
+    All of the fields in [style] are false. *)
 
-val is_activated : _ section -> bool
-(** [is_activated sec] returns `true` if the section must be reported *)
+val must_report_section : _ section -> bool
+(** [must_report_section sec] returns [true] if the section must be reported *)
 
 val has_activated : _ section list -> bool
-(** [has_activated secs] returns `true` if one of the sections must be reported *)
+(** [has_activated secs] returns [true] if one of the sections in [sec] is
+    activated *)
 
-val call_sites_activated : _ section -> bool
-(** [call_sites_activated sec] returns `true` if call sites must be reported in
+val must_report_call_sites : _ section -> bool
+(** [must_report_call_sites sec] returns [true] if call sites must be reported in
     thresholded subsections *)
 
 
@@ -66,26 +67,26 @@ val update_exported_values : string -> t -> t
     [arg]'s specification is the one for the command line option "-E" *)
 
 val update_methods : string -> t -> t
-(** [update_exported_values arg sections] configures the [exported_values]
+(** [update_exported_values arg sections] configures the [methods]
     section according to [arg] and returns an updated version of [sections]
     [arg]'s specification is the one for the command line option "-M" *)
 
 val update_types : string -> t -> t
-(** [update_exported_values arg sections] configures the [exported_values]
+(** [update_exported_values arg sections] configures the [types]
     section according to [arg] and returns an updated version of [sections]
     [arg]'s specification is the one for the command line option "-T" *)
 
 val update_opta : string -> t -> t
-(** [update_exported_values arg sections] configures the [exported_values]
+(** [update_exported_values arg sections] configures the [opta]
     section according to [arg] and returns an updated version of [sections]
     [arg]'s specification is the one for the command line option "-Oa" *)
 
 val update_optn : string -> t -> t
-(** [update_exported_values arg sections] configures the [exported_values]
+(** [update_exported_values arg sections] configures the [optn]
     section according to [arg] and returns an updated version of [sections]
     [arg]'s specification is the one for the command line option "-On" *)
 
 val update_style : string -> t -> t
-(** [update_exported_values arg sections] configures the [exported_values]
+(** [update_exported_values arg sections] configures the [style]
     section according to [arg] and returns an updated version of [sections]
     [arg]'s specification is the one for the command line option "-S" *)

--- a/src/config/sections.mli
+++ b/src/config/sections.mli
@@ -1,0 +1,91 @@
+type t =
+  { exported_values : main_section (** Exported values section config *)
+  ; methods : main_section (** Methods section config *)
+  ; types : main_section (** Constructors/fields section config *)
+  ; opta : opt_args_section (** Opt args always used section config *)
+  ; optn : opt_args_section (** Opt args always used section config *)
+  ; style : style_section (** Stylistic issues section config *)
+  }
+
+and main_section = int section
+
+and opt_args_section = opt_args_threshold section
+and opt_args_threshold =
+  | Percent of float
+      (** Subsections for opt args always/never used at least [float] percent of
+      the time will be reported *)
+  | Both of (int * float)
+      (** Subsections for opt args always/never used with at most [int]
+          exceptions and at least [float] percent of the time will be reported *)
+
+and 'threshold section =
+  | Off (** Disabled *)
+  | On (** Enabled *)
+  | Threshold of 'threshold thresholded_section
+      (** Report elements up to [!'threshold] *)
+
+and 'threshold thresholded_section =
+  { threshold: 'threshold
+      (** Report subsections for elements used up to [!threshold] *)
+  ; call_sites: bool
+      (** Print call sites in the [!threshold]-related subsections *)
+  }
+
+and style_section =
+  { opt_arg: bool (** Report [val f : _ -> (... -> (... -> ?_:_ -> ...) -> ...] *)
+  ; unit_pat: bool (** Report unit pattern *)
+  ; seq: bool (** Report [let () = ... in ... (=> use sequence)] *)
+  ; binding: bool (** Report [let x = ... in x (=> useless binding)] *)
+  }
+
+val default : t
+(** Default sections configuration.
+    [exported],  [obj], and [typ] are [On].
+    [opta], [optn] are [Off].
+    All of the fileds in [style] are false. *)
+
+val is_activated : _ section -> bool
+(** [is_activated sec] returns `true` if the section must be reported *)
+
+val has_activated : _ section list -> bool
+(** [has_activated secs] returns `true` if one of the sections must be reported *)
+
+val call_sites_activated : _ section -> bool
+(** [call_sites_activated sec] returns `true` if call sites must be reported in
+    thresholded subsections *)
+
+
+val get_main_threshold : int section -> int
+(** [get_main_threshold main_sec] returns the threshold if
+    [main_sec = Threshold _], [0] otherwise. *)
+
+
+val update_exported_values : string -> t -> t
+(** [update_exported_values arg sections] configures the [exported_values]
+    section according to [arg] and returns an updated version of [sections].
+    [arg]'s specification is the one for the command line option "-E" *)
+
+val update_methods : string -> t -> t
+(** [update_exported_values arg sections] configures the [exported_values]
+    section according to [arg] and returns an updated version of [sections]
+    [arg]'s specification is the one for the command line option "-M" *)
+
+val update_types : string -> t -> t
+(** [update_exported_values arg sections] configures the [exported_values]
+    section according to [arg] and returns an updated version of [sections]
+    [arg]'s specification is the one for the command line option "-T" *)
+
+val update_opta : string -> t -> t
+(** [update_exported_values arg sections] configures the [exported_values]
+    section according to [arg] and returns an updated version of [sections]
+    [arg]'s specification is the one for the command line option "-Oa" *)
+
+val update_optn : string -> t -> t
+(** [update_exported_values arg sections] configures the [exported_values]
+    section according to [arg] and returns an updated version of [sections]
+    [arg]'s specification is the one for the command line option "-On" *)
+
+val update_style : string -> t -> t
+(** [update_exported_values arg sections] configures the [exported_values]
+    section according to [arg] and returns an updated version of [sections]
+    [arg]'s specification is the one for the command line option "-S" *)

--- a/src/deadArg.ml
+++ b/src/deadArg.ml
@@ -154,7 +154,6 @@ let register_uses val_loc args =
   register_uses builddir val_loc args
 
 let rec bind loc expr =
-  let sections = !Config.config.sections in
   match expr.exp_desc with
   | Texp_function (params, body) -> (
       let check_param_style = function
@@ -163,7 +162,7 @@ let rec bind loc expr =
             DeadType.check_style pat_type expr.exp_loc.Location.loc_start
       in
       let register_optional_param = function
-        | Asttypes.Optional s when Config.has_activated [sections.optn; sections.opta] ->
+        | Asttypes.Optional s when Config.has_opt_args_section_activated () ->
             let (opts, next) = VdNode.get loc in
             VdNode.update loc (s :: opts, next)
         | _ -> ()
@@ -182,7 +181,7 @@ let rec bind loc expr =
       | _ -> ()
     )
   | exp_desc
-    when Config.has_activated [sections.optn; sections.opta]
+    when Config.has_opt_args_section_activated ()
          && DeadType.nb_args ~keep:`Opt expr.exp_type > 0 ->
       let ( let$ ) x f = Option.iter f x in
       let$ loc2 =
@@ -199,7 +198,6 @@ let rec bind loc expr =
                 (********   WRAPPING  ********)
 
 let wrap f x y =
-  let sections = !Config.config.sections in
-  if Config.has_activated [sections.optn; sections.opta] then f x y else ()
+  if Config.has_opt_args_section_activated () then f x y else ()
 
 let register_uses val_loc args = wrap register_uses val_loc args

--- a/src/deadArg.ml
+++ b/src/deadArg.ml
@@ -154,6 +154,7 @@ let register_uses val_loc args =
   register_uses builddir val_loc args
 
 let rec bind loc expr =
+  let sections = !Config.config.sections in
   match expr.exp_desc with
   | Texp_function (params, body) -> (
       let check_param_style = function
@@ -162,7 +163,7 @@ let rec bind loc expr =
             DeadType.check_style pat_type expr.exp_loc.Location.loc_start
       in
       let register_optional_param = function
-        | Asttypes.Optional s when Config.(has_activated [!config.optn; !config.opta]) ->
+        | Asttypes.Optional s when Config.has_activated [sections.optn; sections.opta] ->
             let (opts, next) = VdNode.get loc in
             VdNode.update loc (s :: opts, next)
         | _ -> ()
@@ -181,7 +182,7 @@ let rec bind loc expr =
       | _ -> ()
     )
   | exp_desc
-    when Config.(has_activated [!config.optn; !config.opta])
+    when Config.has_activated [sections.optn; sections.opta]
          && DeadType.nb_args ~keep:`Opt expr.exp_type > 0 ->
       let ( let$ ) x f = Option.iter f x in
       let$ loc2 =
@@ -198,6 +199,7 @@ let rec bind loc expr =
                 (********   WRAPPING  ********)
 
 let wrap f x y =
-  if Config.(has_activated [!config.optn; !config.opta]) then f x y else ()
+  let sections = !Config.config.sections in
+  if Config.has_activated [sections.optn; sections.opta] then f x y else ()
 
 let register_uses val_loc args = wrap register_uses val_loc args

--- a/src/deadArg.ml
+++ b/src/deadArg.ml
@@ -162,7 +162,7 @@ let rec bind loc expr =
             DeadType.check_style pat_type expr.exp_loc.Location.loc_start
       in
       let register_optional_param = function
-        | Asttypes.Optional s when Config.(has_activated [!optn; !opta]) ->
+        | Asttypes.Optional s when Config.(has_activated [!(config.optn); !(config.opta)]) ->
             let (opts, next) = VdNode.get loc in
             VdNode.update loc (s :: opts, next)
         | _ -> ()
@@ -181,7 +181,7 @@ let rec bind loc expr =
       | _ -> ()
     )
   | exp_desc
-    when Config.(has_activated [!optn; !opta])
+    when Config.(has_activated [!(config.optn); !(config.opta)])
          && DeadType.nb_args ~keep:`Opt expr.exp_type > 0 ->
       let ( let$ ) x f = Option.iter f x in
       let$ loc2 =
@@ -198,6 +198,6 @@ let rec bind loc expr =
                 (********   WRAPPING  ********)
 
 let wrap f x y =
-  if Config.(has_activated [!optn; !opta]) then f x y else ()
+  if Config.(has_activated [!(config.optn); !(config.opta)]) then f x y else ()
 
 let register_uses val_loc args = wrap register_uses val_loc args

--- a/src/deadArg.ml
+++ b/src/deadArg.ml
@@ -162,7 +162,7 @@ let rec bind loc expr =
             DeadType.check_style pat_type expr.exp_loc.Location.loc_start
       in
       let register_optional_param = function
-        | Asttypes.Optional s when Config.(!optn.print || !opta.print) ->
+        | Asttypes.Optional s when Config.(has_activated [!optn; !opta]) ->
             let (opts, next) = VdNode.get loc in
             VdNode.update loc (s :: opts, next)
         | _ -> ()
@@ -181,7 +181,7 @@ let rec bind loc expr =
       | _ -> ()
     )
   | exp_desc
-    when (!Config.optn.print || !Config.opta.print)
+    when Config.(has_activated [!optn; !opta])
          && DeadType.nb_args ~keep:`Opt expr.exp_type > 0 ->
       let ( let$ ) x f = Option.iter f x in
       let$ loc2 =
@@ -198,6 +198,6 @@ let rec bind loc expr =
                 (********   WRAPPING  ********)
 
 let wrap f x y =
-  if Config.(!optn.print || !opta.print) then f x y else ()
+  if Config.(has_activated [!optn; !opta]) then f x y else ()
 
 let register_uses val_loc args = wrap register_uses val_loc args

--- a/src/deadArg.ml
+++ b/src/deadArg.ml
@@ -162,7 +162,7 @@ let rec bind loc expr =
             DeadType.check_style pat_type expr.exp_loc.Location.loc_start
       in
       let register_optional_param = function
-        | Asttypes.Optional s when Config.(has_activated [!(config.optn); !(config.opta)]) ->
+        | Asttypes.Optional s when Config.(has_activated [!config.optn; !config.opta]) ->
             let (opts, next) = VdNode.get loc in
             VdNode.update loc (s :: opts, next)
         | _ -> ()
@@ -181,7 +181,7 @@ let rec bind loc expr =
       | _ -> ()
     )
   | exp_desc
-    when Config.(has_activated [!(config.optn); !(config.opta)])
+    when Config.(has_activated [!config.optn; !config.opta])
          && DeadType.nb_args ~keep:`Opt expr.exp_type > 0 ->
       let ( let$ ) x f = Option.iter f x in
       let$ loc2 =
@@ -198,6 +198,6 @@ let rec bind loc expr =
                 (********   WRAPPING  ********)
 
 let wrap f x y =
-  if Config.(has_activated [!(config.optn); !(config.opta)]) then f x y else ()
+  if Config.(has_activated [!config.optn; !config.opta]) then f x y else ()
 
 let register_uses val_loc args = wrap register_uses val_loc args

--- a/src/deadArg.ml
+++ b/src/deadArg.ml
@@ -162,7 +162,7 @@ let rec bind loc expr =
             DeadType.check_style pat_type expr.exp_loc.Location.loc_start
       in
       let register_optional_param = function
-        | Asttypes.Optional s when DeadFlag.(!optn.print || !opta.print) ->
+        | Asttypes.Optional s when Config.(!optn.print || !opta.print) ->
             let (opts, next) = VdNode.get loc in
             VdNode.update loc (s :: opts, next)
         | _ -> ()
@@ -181,7 +181,7 @@ let rec bind loc expr =
       | _ -> ()
     )
   | exp_desc
-    when (!DeadFlag.optn.print || !DeadFlag.opta.print)
+    when (!Config.optn.print || !Config.opta.print)
          && DeadType.nb_args ~keep:`Opt expr.exp_type > 0 ->
       let ( let$ ) x f = Option.iter f x in
       let$ loc2 =
@@ -198,6 +198,6 @@ let rec bind loc expr =
                 (********   WRAPPING  ********)
 
 let wrap f x y =
-  if DeadFlag.(!optn.print || !opta.print) then f x y else ()
+  if Config.(!optn.print || !opta.print) then f x y else ()
 
 let register_uses val_loc args = wrap register_uses val_loc args

--- a/src/deadArg.ml
+++ b/src/deadArg.ml
@@ -164,7 +164,7 @@ let rec bind loc expr =
       in
       let register_optional_param = function
         | Asttypes.Optional s
-          when Config.has_opt_args_section_activated state.config ->
+          when Config.must_report_opt_args state.config ->
             let (opts, next) = VdNode.get loc in
             VdNode.update loc (s :: opts, next)
         | _ -> ()
@@ -183,7 +183,7 @@ let rec bind loc expr =
       | _ -> ()
     )
   | exp_desc
-    when Config.has_opt_args_section_activated state.config
+    when Config.must_report_opt_args state.config
          && DeadType.nb_args ~keep:`Opt expr.exp_type > 0 ->
       let ( let$ ) x f = Option.iter f x in
       let$ loc2 =
@@ -201,7 +201,7 @@ let rec bind loc expr =
 
 let wrap f x y =
   let state = State.get_current () in
-  if Config.has_opt_args_section_activated state.config then
+  if Config.must_report_opt_args state.config then
     f x y
   else ()
 

--- a/src/deadCode.ml
+++ b/src/deadCode.ml
@@ -640,93 +640,12 @@ let report_style () =
 
 (* Option parsing and processing *)
 let parse () =
-  let update_all print () =
-    Config.(
-    update_style ((if print = "all" then "+" else "-") ^ "all");
-    update_main "-E" config.exported print;
-    update_main "-M" config.obj print;
-    update_main "-T" config.typ print;
-    update_opt config.opta print;
-    update_opt config.optn print)
-  in
-
-  let load_file filename =
+  let process_file filename =
     let state = State.get_current () in
     let state = load_file state filename in
     State.update state
   in
-
-  (* any extra argument can be accepted by any option using some
-   * although it doesn't necessary affects the results (e.g. -O 3+4) *)
-  Arg.(parse
-    [ "--exclude", String Config.exclude, "<path>  Exclude given path from research.";
-
-      "--references",
-        String (fun dir -> Config.config.directories <- dir :: Config.config.directories),
-        "<path>  Consider given path to collect references.";
-
-      "--underscore", Unit Config.set_underscore, " Show names starting with an underscore";
-
-      "--verbose", Unit Config.set_verbose, " Verbose mode (ie., show scanned files)";
-      "-v", Unit Config.set_verbose, " See --verbose";
-
-      "--internal", Unit Config.set_internal,
-        " Keep internal uses as exported values uses when the interface is given. \
-          This is the default behaviour when only the implementation is found";
-
-      "--nothing", Unit (update_all "nothing"), " Disable all warnings";
-      "-a", Unit (update_all "nothing"), " See --nothing";
-      "--all", Unit (update_all "all"), " Enable all warnings";
-      "-A", Unit (update_all "all"), " See --all";
-
-      "-E", String (Config.update_main "-E" Config.config.exported),
-        "<display>  Enable/Disable unused exported values warnings.\n    \
-        <display> can be:\n\
-          \tall\n\
-          \tnothing\n\
-          \t\"threshold:<integer>\": report elements used up to the given integer\n\
-          \t\"calls:<integer>\": like threshold + show call sites";
-
-      "-M", String (Config.update_main "-M" Config.config.obj),
-        "<display>  Enable/Disable unused methods warnings.\n    \
-        See option -E for the syntax of <display>";
-
-      "-Oa", String (Config.update_opt Config.config.opta),
-        "<display>  Enable/Disable optional arguments always used warnings.\n    \
-        <display> can be:\n\
-          \tall\n\
-          \tnothing\n\
-          \t<threshold>\n\
-          \t\"calls:<threshold>\" like <threshold> + show call sites\n    \
-        <threshold> can be:\n\
-          \t\"both:<integer>,<float>\": both the number max of exceptions \
-          (given through the integer) and the percent of valid cases (given as a float) \
-          must be respected for the element to be reported\n\
-          \t\"percent:<float>\": percent of valid cases to be reported";
-
-      "-On", String (Config.update_opt Config.config.optn),
-        "<display>  Enable/Disable optional arguments never used warnings.\n    \
-        See option -Oa for the syntax of <display>";
-
-      "-S", String (Config.update_style),
-        " Enable/Disable coding style warnings.\n    \
-        Delimiters '+' and '-' determine if the following option is to enable or disable.\n    \
-        Options (can be used together):\n\
-          \tbind: useless binding\n\
-          \topt: optional arg in arg\n\
-          \tseq: use sequence\n\
-          \tunit: unit pattern\n\
-          \tall: bind & opt & seq & unit";
-
-      "-T", String (Config.update_main "-T" Config.config.typ),
-        "<display>  Enable/Disable unused constructors/records fields warnings.\n    \
-        See option -E for the syntax of <display>";
-
-    ]
-    (Printf.eprintf "Scanning files...\n%!";
-     load_file)
-    ("Usage: " ^ Sys.argv.(0) ^ " <options> <path>\nOptions are:"))
-
+  Config.parse_cli process_file
 
 let () =
 try

--- a/src/deadCode.ml
+++ b/src/deadCode.ml
@@ -555,13 +555,13 @@ let report_opt_args s l =
               (* TODO: better error handling *)
               failwith "Trying to report a deactivated opt args section"
           | On -> ratio >= 1. && nb_call = 0
-          | Threshold {threshold = {percentage; optional = `Both; _}; _} ->
+          | Threshold {threshold = Both (_, percentage); _} ->
               ratio >= percentage && check_length nb_call slot
-          | Threshold {threshold; _} ->
+          | Threshold {threshold = Percent percentage as threshold; _} ->
               let percent = percent threshold in
 
               ratio >= percent nb_call
-              && (threshold.percentage >= 1. || ratio < (percent (nb_call - 1))))
+              && (percentage >= 1. || ratio < (percent (nb_call - 1))))
       @@ List.map
         (fun (builddir, loc, lab, slot) ->
           let l = if s = "NEVER" then slot.with_val else slot.without_val in
@@ -602,10 +602,10 @@ let report_opt_args s l =
     let continue nb_call =
       match opt with
       | Off | On -> false
-      | Threshold {threshold = {optional = `Both; exceptions; _}; _} ->
+      | Threshold {threshold = Both (exceptions, _); _} ->
           nb_call < exceptions
-      | Threshold {threshold; _} ->
-          percent threshold nb_call > threshold.percentage
+      | Threshold {threshold = Percent percentage as threshold; _} ->
+          percent threshold nb_call > percentage
     in
     let s =
       (if nb_call > 0 then "OPTIONAL ARGUMENTS: ALMOST "

--- a/src/deadCode.ml
+++ b/src/deadCode.ml
@@ -238,7 +238,7 @@ let expr super self e =
 
 
   | Texp_apply (exp, args) ->
-      if Config.has_activated [sections.opta; sections.optn] then
+      if Config.has_opt_args_section_activated () then
         treat_exp exp args;
       begin match exp.exp_desc with
       | Texp_ident (_, _, {Types.val_loc; _})
@@ -361,9 +361,8 @@ let regabs state =
 let read_interface fn cmi_infos state = let open Cmi_format in
   try
     regabs state;
-    let sections = !Config.config.sections in
     if
-      Config.has_activated [sections.exported_values; sections.methods; sections.types]
+      Config.has_main_section_activated ()
     then
       let u =
         if State.File_infos.has_sourcepath state.file_infos then
@@ -677,7 +676,7 @@ try
     if Config.is_activated sections.exported_values then report_unused_exported ();
     DeadObj.report();
     DeadType.report();
-    if Config.has_activated [sections.opta; sections.optn] then begin
+    if Config.has_opt_args_section_activated () then begin
       let tmp = analyze_opt_args () in
       if Config.is_activated sections.opta then  report_opt_args "ALWAYS" tmp;
       if Config.is_activated sections.optn then  report_opt_args "NEVER" tmp

--- a/src/deadCode.ml
+++ b/src/deadCode.ml
@@ -663,7 +663,10 @@ try
       DeadCommon.declarations := false;
       let oldsections = !Config.config.sections in
       Config.update_style "-all";
-      List.fold_left load_file state !Config.config.directories
+      Config.StringSet.fold
+        (fun path state -> load_file state path)
+        !Config.config.references_paths
+        state
       |> ignore;
       Config.(config := {!config with sections = oldsections})
     in

--- a/src/deadCode.ml
+++ b/src/deadCode.ml
@@ -36,7 +36,7 @@ let rec collect_export ?(mod_type = false) path u stock = function
   | Sig_value (id, ({Types.val_loc; val_type; _} as value), _)
     when not val_loc.Location.loc_ghost ->
       let should_export stock loc =
-        Config.(is_activated !config.exported)
+        Config.(is_activated !config.sections.exported_values)
         && (* do not add the loc in decs if it belongs to a module type *)
           ( stock != decs
             || not (Hashtbl.mem in_modtype loc.Location.loc_start)
@@ -129,14 +129,16 @@ let value_binding super self x =
 
 let structure_item super self i =
   let state = State.get_current () in
+  let sections = !Config.config.sections in
   let open Asttypes in
   begin match i.str_desc with
-  | Tstr_type  (_, l) when Config.(is_activated !config.typ) ->
+  | Tstr_type  (_, l) when Config.is_activated sections.types ->
       List.iter DeadType.tstr l
   | Tstr_module  {mb_name = {txt = Some txt; _}; _} ->
       mods := txt :: !mods;
       DeadMod.defined := String.concat "." (List.rev !mods) :: !DeadMod.defined
-  | Tstr_class l when Config.(is_activated !config.obj) -> List.iter DeadObj.tstr l
+  | Tstr_class l when Config.is_activated sections.methods ->
+      List.iter DeadObj.tstr l
   | Tstr_include i ->
       let collect_include signature =
         let prev_last_loc = !last_loc in
@@ -172,12 +174,13 @@ let structure_item super self i =
 
 let pat: type k. Tast_mapper.mapper -> Tast_mapper.mapper -> k general_pattern -> k general_pattern =
  fun super self p ->
+  let sections = !Config.config.sections in
   let pat_loc = p.pat_loc.Location.loc_start in
   let u s =
     register_style pat_loc (Printf.sprintf "unit pattern %s" s)
   in
   let open Asttypes in
-  if DeadType.is_unit p.pat_type && !Config.config.style.unit_pat then begin
+  if DeadType.is_unit p.pat_type && sections.style.unit_pat then begin
     match p.pat_desc with
       | Tpat_construct _ -> ()
       | Tpat_var (_, {txt = "eta"; loc = _}, _)
@@ -195,7 +198,7 @@ let pat: type k. Tast_mapper.mapper -> Tast_mapper.mapper -> k general_pattern -
   | Tpat_record (l, _) ->
       List.iter
         (fun (_, {Types.lbl_loc = {Location.loc_start = lab_loc; _}; _}, _) ->
-           if exported ~is_type:true !Config.config.typ lab_loc then
+           if exported ~is_type:true sections.types lab_loc then
             DeadType.collect_references lab_loc pat_loc
         )
         l
@@ -205,6 +208,7 @@ let pat: type k. Tast_mapper.mapper -> Tast_mapper.mapper -> k general_pattern -
 
 
 let expr super self e =
+  let sections = !Config.config.sections in
   let rec extra = function
     | [] -> ()
     | (Texp_coerce (_, typ), _, _)::l -> DeadObj.coerce e typ.ctyp_type; extra l
@@ -218,12 +222,12 @@ let expr super self e =
       !DeadLexiFi.ttype_of e
 
   | Texp_ident (_, _, {Types.val_loc = {Location.loc_start = loc; loc_ghost = false; _}; _})
-    when exported !Config.config.exported loc ->
+    when exported sections.exported_values loc ->
       LocHash.add_set references loc exp_loc
 
   | Texp_field (_, _, {lbl_loc = {Location.loc_start = loc; loc_ghost = false; _}; _})
   | Texp_construct (_, {cstr_loc = {Location.loc_start = loc; loc_ghost = false; _}; _}, _)
-    when exported ~is_type:true !Config.config.typ loc ->
+    when exported ~is_type:true sections.types loc ->
       DeadType.collect_references loc exp_loc
 
   | Texp_send (e2, Tmeth_name meth) ->
@@ -234,7 +238,8 @@ let expr super self e =
 
 
   | Texp_apply (exp, args) ->
-      if Config.(has_activated [!config.opta; !config.optn]) then treat_exp exp args;
+      if Config.has_activated [sections.opta; sections.optn] then
+        treat_exp exp args;
       begin match exp.exp_desc with
       | Texp_ident (_, _, {Types.val_loc; _})
         when val_loc.Location.loc_ghost -> (* The node is due to lookup preparation
@@ -248,7 +253,7 @@ let expr super self e =
       end
 
   | Texp_let (_, [{vb_pat; _}], _)
-    when DeadType.is_unit vb_pat.pat_type && !Config.config.style.seq ->
+    when DeadType.is_unit vb_pat.pat_type && sections.style.seq ->
       begin match vb_pat.pat_desc with
       | Tpat_var (id, _, _) when not (check_underscore (Ident.name id)) -> ()
       | _ ->
@@ -258,7 +263,7 @@ let expr super self e =
       end
 
   | Texp_match (_, [{c_lhs; _}], _)
-    when DeadType.is_unit c_lhs.pat_type && !Config.config.style.seq ->
+    when DeadType.is_unit c_lhs.pat_type && sections.style.seq ->
       begin match c_lhs.pat_desc with
       | Tpat_value tpat_arg ->
         begin match (tpat_arg :> value general_pattern) with
@@ -276,7 +281,7 @@ let expr super self e =
         [{vb_pat = {pat_desc = Tpat_var (id1, _, _); pat_loc = {loc_start = loc; _}; _}; _}],
         {exp_desc = Texp_ident (Path.Pident id2, _, _); exp_extra = []; _})
     when id1 = id2
-         && !Config.config.style.binding
+         && sections.style.binding
          && check_underscore (Ident.name id1) ->
       register_style loc "let x = ... in x (=> useless binding)"
 
@@ -356,7 +361,10 @@ let regabs state =
 let read_interface fn cmi_infos state = let open Cmi_format in
   try
     regabs state;
-    if Config.(has_activated [!config.exported; !config.obj; !config.typ]) then
+    let sections = !Config.config.sections in
+    if
+      Config.has_activated [sections.exported_values; sections.methods; sections.types]
+    then
       let u =
         if State.File_infos.has_sourcepath state.file_infos then
           State.File_infos.get_sourceunit state.file_infos
@@ -480,7 +488,7 @@ let rec load_file state fn =
           ignore (collect_references.Tast_mapper.structure collect_references x);
 
           let loc_dep =
-            if Config.(is_activated !config.exported) then
+            if Config.(is_activated !config.sections.exported_values) then
               List.rev_map
                 (fun (vd1, vd2) ->
                   (vd1.Types.val_loc.Location.loc_start, vd2.Types.val_loc.Location.loc_start)
@@ -543,11 +551,10 @@ let analyze_opt_args () =
 
 let report_opt_args s l =
   let opt =
-    if s = "NEVER" then !Config.config.optn
-    else !Config.config.opta
+    if s = "NEVER" then !Config.config.sections.optn
+    else !Config.config.sections.opta
   in
   let rec report_opt_args nb_call =
-    let open Config in
     let l = List.filter
         (fun (_, _, _, slot, ratio, _) -> let ratio = 1. -. ratio in
           match  opt with
@@ -617,7 +624,10 @@ let report_opt_args s l =
 
 
 let report_unused_exported () =
-  report_basic decs "UNUSED EXPORTED VALUES" !Config.config.exported
+  report_basic
+    decs
+    "UNUSED EXPORTED VALUES"
+    !Config.config.sections.exported_values
 
 
 let report_style () =
@@ -652,27 +662,29 @@ try
     parse ();
     let run_on_references_only state =
       DeadCommon.declarations := false;
-      let oldstyle = !Config.config.style in
+      let oldsections = !Config.config.sections in
       Config.update_style "-all";
       List.fold_left load_file state !Config.config.directories
       |> ignore;
-      Config.(config := {!config with style = oldstyle})
+      Config.(config := {!config with sections = oldsections})
     in
     run_on_references_only (State.get_current ());
 
     Printf.eprintf " [DONE]\n\n%!";
 
     !DeadLexiFi.prepare_report DeadType.decs;
-    if Config.(is_activated !config.exported) then report_unused_exported ();
+    let sections = !Config.config.sections in
+    if Config.is_activated sections.exported_values then report_unused_exported ();
     DeadObj.report();
     DeadType.report();
-    if Config.(has_activated [!config.opta; !config.optn]) then begin
+    if Config.has_activated [sections.opta; sections.optn] then begin
       let tmp = analyze_opt_args () in
-      if Config.(is_activated !config.opta) then  report_opt_args "ALWAYS" tmp;
-      if Config.(is_activated !config.optn) then  report_opt_args "NEVER" tmp
+      if Config.is_activated sections.opta then  report_opt_args "ALWAYS" tmp;
+      if Config.is_activated sections.optn then  report_opt_args "NEVER" tmp
     end;
+    let style = sections.style in
     if [@warning "-44"]
-      Config.(!config.style.opt_arg || !config.style.unit_pat || !config.style.seq || !config.style.binding)
+      style.opt_arg || style.unit_pat || style.seq || style.binding
     then report_style ();
 
     if !bad_files <> [] then begin

--- a/src/deadCode.ml
+++ b/src/deadCode.ml
@@ -36,7 +36,7 @@ let rec collect_export ?(mod_type = false) path u stock = function
   | Sig_value (id, ({Types.val_loc; val_type; _} as value), _)
     when not val_loc.Location.loc_ghost ->
       let should_export stock loc =
-        Config.(is_activated !exported)
+        Config.(is_activated !(config.exported))
         && (* do not add the loc in decs if it belongs to a module type *)
           ( stock != decs
             || not (Hashtbl.mem in_modtype loc.Location.loc_start)
@@ -131,12 +131,12 @@ let structure_item super self i =
   let state = State.get_current () in
   let open Asttypes in
   begin match i.str_desc with
-  | Tstr_type  (_, l) when Config.(is_activated !typ) ->
+  | Tstr_type  (_, l) when Config.(is_activated !(config.typ)) ->
       List.iter DeadType.tstr l
   | Tstr_module  {mb_name = {txt = Some txt; _}; _} ->
       mods := txt :: !mods;
       DeadMod.defined := String.concat "." (List.rev !mods) :: !DeadMod.defined
-  | Tstr_class l when Config.(is_activated !obj) -> List.iter DeadObj.tstr l
+  | Tstr_class l when Config.(is_activated !(config.obj)) -> List.iter DeadObj.tstr l
   | Tstr_include i ->
       let collect_include signature =
         let prev_last_loc = !last_loc in
@@ -177,13 +177,13 @@ let pat: type k. Tast_mapper.mapper -> Tast_mapper.mapper -> k general_pattern -
     register_style pat_loc (Printf.sprintf "unit pattern %s" s)
   in
   let open Asttypes in
-  if DeadType.is_unit p.pat_type && !Config.style.Config.unit_pat then begin
+  if DeadType.is_unit p.pat_type && !Config.(config.style).unit_pat then begin
     match p.pat_desc with
       | Tpat_construct _ -> ()
       | Tpat_var (_, {txt = "eta"; loc = _}, _)
         when p.pat_loc = Location.none -> ()
       | Tpat_var (_, {txt; _}, _) -> if check_underscore txt then u txt
-      | Tpat_any -> if not !Config.underscore then u "_"
+      | Tpat_any -> if Config.config.underscore then u "_"
       | Tpat_value tpat_arg ->
         begin match (tpat_arg :> value general_pattern) with
         | {pat_desc=Tpat_construct _; _} -> ()
@@ -195,7 +195,7 @@ let pat: type k. Tast_mapper.mapper -> Tast_mapper.mapper -> k general_pattern -
   | Tpat_record (l, _) ->
       List.iter
         (fun (_, {Types.lbl_loc = {Location.loc_start = lab_loc; _}; _}, _) ->
-          if exported Config.typ lab_loc then
+          if exported Config.config.typ lab_loc then
             DeadType.collect_references lab_loc pat_loc
         )
         l
@@ -218,12 +218,12 @@ let expr super self e =
       !DeadLexiFi.ttype_of e
 
   | Texp_ident (_, _, {Types.val_loc = {Location.loc_start = loc; loc_ghost = false; _}; _})
-    when exported Config.exported loc ->
+    when exported Config.config.exported loc ->
       LocHash.add_set references loc exp_loc
 
   | Texp_field (_, _, {lbl_loc = {Location.loc_start = loc; loc_ghost = false; _}; _})
   | Texp_construct (_, {cstr_loc = {Location.loc_start = loc; loc_ghost = false; _}; _}, _)
-    when exported Config.typ loc ->
+    when exported Config.config.typ loc ->
       DeadType.collect_references loc exp_loc
 
   | Texp_send (e2, Tmeth_name meth) ->
@@ -234,7 +234,7 @@ let expr super self e =
 
 
   | Texp_apply (exp, args) ->
-      if Config.(has_activated [!opta; !optn]) then treat_exp exp args;
+      if Config.(has_activated [!(config.opta); !(config.optn)]) then treat_exp exp args;
       begin match exp.exp_desc with
       | Texp_ident (_, _, {Types.val_loc; _})
         when val_loc.Location.loc_ghost -> (* The node is due to lookup preparation
@@ -248,7 +248,7 @@ let expr super self e =
       end
 
   | Texp_let (_, [{vb_pat; _}], _)
-    when DeadType.is_unit vb_pat.pat_type && !Config.style.Config.seq ->
+    when DeadType.is_unit vb_pat.pat_type && !Config.(config.style).seq ->
       begin match vb_pat.pat_desc with
       | Tpat_var (id, _, _) when not (check_underscore (Ident.name id)) -> ()
       | _ ->
@@ -258,7 +258,7 @@ let expr super self e =
       end
 
   | Texp_match (_, [{c_lhs; _}], _)
-    when DeadType.is_unit c_lhs.pat_type && !Config.style.Config.seq ->
+    when DeadType.is_unit c_lhs.pat_type && !Config.(config.style).seq ->
       begin match c_lhs.pat_desc with
       | Tpat_value tpat_arg ->
         begin match (tpat_arg :> value general_pattern) with
@@ -276,7 +276,7 @@ let expr super self e =
         [{vb_pat = {pat_desc = Tpat_var (id1, _, _); pat_loc = {loc_start = loc; _}; _}; _}],
         {exp_desc = Texp_ident (Path.Pident id2, _, _); exp_extra = []; _})
     when id1 = id2
-         && !Config.style.Config.binding
+         && !Config.(config.style).binding
          && check_underscore (Ident.name id1) ->
       register_style loc "let x = ... in x (=> useless binding)"
 
@@ -356,7 +356,7 @@ let regabs state =
 let read_interface fn cmi_infos state = let open Cmi_format in
   try
     regabs state;
-    if Config.(has_activated [!exported; !obj; !typ]) then
+    if Config.(has_activated [!(config.exported); !(config.obj); !(config.typ)]) then
       let u =
         if State.File_infos.has_sourcepath state.file_infos then
           State.File_infos.get_sourceunit state.file_infos
@@ -394,7 +394,7 @@ let assoc decs (loc1, loc2) =
     || not (is_implem fn && has_iface fn)
   in
   if fn1 <> _none && fn2 <> _none && loc1 <> loc2 then begin
-    if (!Config.internal || fn1 <> fn2) && is_implem fn1 && is_implem fn2 then
+    if (Config.config.internal || fn1 <> fn2) && is_implem fn1 && is_implem fn2 then
       DeadCommon.LocHash.merge_set references loc2 references loc1;
     if is_iface fn1 loc1 then begin
       if is_iface fn2 loc2 then
@@ -452,7 +452,7 @@ let rec load_file state fn =
   match kind fn with
   | `Cmi when !DeadCommon.declarations ->
       last_loc := Lexing.dummy_pos;
-      if !Config.verbose then Printf.eprintf "Scanning %s\n%!" fn;
+      if Config.config.verbose then Printf.eprintf "Scanning %s\n%!" fn;
       init_and_continue state fn (fun state ->
       match state.file_infos.cmi_infos with
       | None -> () (* TODO error handling ? *) 
@@ -462,7 +462,7 @@ let rec load_file state fn =
   | `Cmt ->
       let open Cmt_format in
       last_loc := Lexing.dummy_pos;
-      if !Config.verbose then Printf.eprintf "Scanning %s\n%!" fn;
+      if Config.config.verbose then Printf.eprintf "Scanning %s\n%!" fn;
       init_and_continue state fn (fun state ->
       regabs state;
       match state.file_infos.cmt_infos with
@@ -480,7 +480,7 @@ let rec load_file state fn =
           ignore (collect_references.Tast_mapper.structure collect_references x);
 
           let loc_dep =
-            if Config.(is_activated !exported) then
+            if Config.(is_activated !(config.exported)) then
               List.rev_map
                 (fun (vd1, vd2) ->
                   (vd1.Types.val_loc.Location.loc_start, vd2.Types.val_loc.Location.loc_start)
@@ -543,8 +543,8 @@ let analyze_opt_args () =
 
 let report_opt_args s l =
   let opt =
-    if s = "NEVER" then !Config.optn
-    else !Config.opta
+    if s = "NEVER" then !Config.(config.optn)
+    else !Config.(config.opta)
   in
   let rec report_opt_args nb_call =
     let open Config in
@@ -616,7 +616,8 @@ let report_opt_args s l =
   in report_opt_args 0
 
 
-let report_unused_exported () = report_basic decs "UNUSED EXPORTED VALUES" !Config.exported
+let report_unused_exported () =
+  report_basic decs "UNUSED EXPORTED VALUES" !Config.(config.exported)
 
 
 let report_style () =
@@ -642,11 +643,11 @@ let parse () =
   let update_all print () =
     Config.(
     update_style ((if print = "all" then "+" else "-") ^ "all");
-    update_main "-E" Config.exported print;
-    update_main "-M" obj print;
-    update_main "-T" typ print;
-    update_opt opta print;
-    update_opt optn print)
+    update_main "-E" config.exported print;
+    update_main "-M" config.obj print;
+    update_main "-T" config.typ print;
+    update_opt config.opta print;
+    update_opt config.optn print)
   in
 
   let load_file filename =
@@ -661,7 +662,7 @@ let parse () =
     [ "--exclude", String Config.exclude, "<path>  Exclude given path from research.";
 
       "--references",
-        String (fun dir -> Config.directories := dir :: !Config.directories),
+        String (fun dir -> Config.config.directories <- dir :: Config.config.directories),
         "<path>  Consider given path to collect references.";
 
       "--underscore", Unit Config.set_underscore, " Show names starting with an underscore";
@@ -678,7 +679,7 @@ let parse () =
       "--all", Unit (update_all "all"), " Enable all warnings";
       "-A", Unit (update_all "all"), " See --all";
 
-      "-E", String (Config.update_main "-E" Config.exported),
+      "-E", String (Config.update_main "-E" Config.config.exported),
         "<display>  Enable/Disable unused exported values warnings.\n    \
         <display> can be:\n\
           \tall\n\
@@ -686,11 +687,11 @@ let parse () =
           \t\"threshold:<integer>\": report elements used up to the given integer\n\
           \t\"calls:<integer>\": like threshold + show call sites";
 
-      "-M", String (Config.update_main "-M" Config.obj),
+      "-M", String (Config.update_main "-M" Config.config.obj),
         "<display>  Enable/Disable unused methods warnings.\n    \
         See option -E for the syntax of <display>";
 
-      "-Oa", String (Config.update_opt Config.opta),
+      "-Oa", String (Config.update_opt Config.config.opta),
         "<display>  Enable/Disable optional arguments always used warnings.\n    \
         <display> can be:\n\
           \tall\n\
@@ -703,7 +704,7 @@ let parse () =
           must be respected for the element to be reported\n\
           \t\"percent:<float>\": percent of valid cases to be reported";
 
-      "-On", String (Config.update_opt Config.optn),
+      "-On", String (Config.update_opt Config.config.optn),
         "<display>  Enable/Disable optional arguments never used warnings.\n    \
         See option -Oa for the syntax of <display>";
 
@@ -717,7 +718,7 @@ let parse () =
           \tunit: unit pattern\n\
           \tall: bind & opt & seq & unit";
 
-      "-T", String (Config.update_main "-T" Config.typ),
+      "-T", String (Config.update_main "-T" Config.config.typ),
         "<display>  Enable/Disable unused constructors/records fields warnings.\n    \
         See option -E for the syntax of <display>";
 
@@ -732,27 +733,27 @@ try
     parse ();
     let run_on_references_only state =
       DeadCommon.declarations := false;
-      let oldstyle = !Config.style in
+      let oldstyle = !Config.(config.style) in
       Config.update_style "-all";
-      List.fold_left load_file state !Config.directories
+      List.fold_left load_file state Config.config.directories
       |> ignore;
-      Config.style := oldstyle
+      Config.config.style := oldstyle
     in
     run_on_references_only (State.get_current ());
 
     Printf.eprintf " [DONE]\n\n%!";
 
     !DeadLexiFi.prepare_report DeadType.decs;
-    if Config.(is_activated !exported) then report_unused_exported ();
+    if Config.(is_activated !(config.exported)) then report_unused_exported ();
     DeadObj.report();
     DeadType.report();
-    if Config.(has_activated [!opta; !optn]) then begin
+    if Config.(has_activated [!(config.opta); !(config.optn)]) then begin
       let tmp = analyze_opt_args () in
-      if Config.(is_activated !opta) then  report_opt_args "ALWAYS" tmp;
-      if Config.(is_activated !optn) then  report_opt_args "NEVER" tmp
+      if Config.(is_activated !(config.opta)) then  report_opt_args "ALWAYS" tmp;
+      if Config.(is_activated !(config.optn)) then  report_opt_args "NEVER" tmp
     end;
     if [@warning "-44"]
-      Config.(!style.opt_arg || !style.unit_pat || !style.seq || !style.binding)
+      Config.(!(config.style).opt_arg || !(config.style).unit_pat || !(config.style).seq || !(config.style).binding)
     then report_style ();
 
     if !bad_files <> [] then begin

--- a/src/deadCommon.ml
+++ b/src/deadCommon.ml
@@ -140,7 +140,7 @@ let rec get_deep_desc typ =
   | t -> t
 
 
-let exported ?(is_type = false) (flag : Config.main_section) loc =
+let exported ?(is_type = false) (flag : Config.Sections.main_section) loc =
   let state = State.get_current () in
   let fn = loc.Lexing.pos_fname in
   let sourceunit = State.File_infos.get_sourceunit state.file_infos in
@@ -432,7 +432,7 @@ let pretty_print_call () = let ghost = ref false in function
       ghost := true
 
 
-let percent (opt_threshold : Config.opt_threshold) base =
+let percent (opt_threshold : Config.Sections.opt_args_threshold) base =
   let percentage =
     match opt_threshold with
     | Percent p | Both (_, p) -> p
@@ -441,7 +441,9 @@ let percent (opt_threshold : Config.opt_threshold) base =
 
 
 (* Base pattern for reports *)
-let report s ~(opt: Config.opt_section) ?(extra = "Called") l continue nb_call pretty_print reporter =
+let report s ~(opt: Config.Sections.opt_args_section) ?(extra = "Called") l
+           continue nb_call pretty_print reporter
+=
   if nb_call = 0 || l <> [] then begin
     section ~sub:(nb_call <> 0)
     @@ (if nb_call = 0 then s
@@ -464,7 +466,7 @@ let report s ~(opt: Config.opt_section) ?(extra = "Called") l continue nb_call p
   else (print_newline () |> separator)
 
 
-let report_basic ?folder decs title (flag:Config.main_section) =
+let report_basic ?folder decs title (flag:Config.Sections.main_section) =
   let folder = match folder with
     | Some folder -> folder
     | None -> fun nb_call -> fun loc (builddir, path) acc ->
@@ -522,7 +524,7 @@ let report_basic ?folder decs title (flag:Config.main_section) =
       if nb_call = 0 then title
       else "ALMOST " ^ title
     in
-    report s ~opt:(!Config.config.opta) l continue nb_call pretty_print reportn
+    report s ~opt:(!Config.config.sections.opta) l continue nb_call pretty_print reportn
 
   in reportn 0
 

--- a/src/deadCommon.ml
+++ b/src/deadCommon.ml
@@ -84,7 +84,7 @@ let is_ghost loc =
   || loc.Lexing.pos_fname = _none || loc.Lexing.pos_fname = ""
 
 
-let check_underscore name = Config.config.underscore || name.[0] <> '_'
+let check_underscore name = !Config.config.underscore || name.[0] <> '_'
 
 
 let hashtbl_find_list hashtbl key = Hashtbl.find_all hashtbl key
@@ -140,15 +140,15 @@ let rec get_deep_desc typ =
   | t -> t
 
 
-let exported (flag : Config.main_section ref) loc =
+let exported ?(is_type = false) (flag : Config.main_section) loc =
   let state = State.get_current () in
   let fn = loc.Lexing.pos_fname in
   let sourceunit = State.File_infos.get_sourceunit state.file_infos in
-  Config.is_activated !flag
+  Config.is_activated flag
   && LocHash.find_set references loc
-     |> LocSet.cardinal <= Config.get_main_threshold !flag
-  && (flag == Config.config.typ
-    || Config.config.internal
+     |> LocSet.cardinal <= Config.get_main_threshold flag
+  && (is_type
+    || !Config.config.internal
     || fn.[String.length fn - 1] = 'i'
     || sourceunit <> Utils.unit fn
     || not (file_exists (fn ^ "i")))
@@ -522,7 +522,7 @@ let report_basic ?folder decs title (flag:Config.main_section) =
       if nb_call = 0 then title
       else "ALMOST " ^ title
     in
-    report s ~opt:(!Config.(config.opta)) l continue nb_call pretty_print reportn
+    report s ~opt:(!Config.config.opta) l continue nb_call pretty_print reportn
 
   in reportn 0
 

--- a/src/deadCommon.ml
+++ b/src/deadCommon.ml
@@ -433,8 +433,11 @@ let pretty_print_call () = let ghost = ref false in function
 
 
 let percent (opt_threshold : Config.opt_threshold) base =
-  let open Config in
-  1. -. (float_of_int base) *. (1. -. opt_threshold.percentage) /. 10.
+  let percentage =
+    match opt_threshold with
+    | Percent p | Both (_, p) -> p
+  in
+  1. -. (float_of_int base) *. (1. -. percentage) /. 10.
 
 
 (* Base pattern for reports *)
@@ -445,11 +448,9 @@ let report s ~(opt: Config.opt_section) ?(extra = "Called") l continue nb_call p
         else if String.equal extra "Called" then
           Printf.sprintf "%s: %s %d time(s)" s extra nb_call
         else match opt with
-        | Threshold {threshold; _} ->
-          if threshold.optional = `Both || extra = "Called"
-          then
+        | Threshold {threshold = Both _; _} ->
             Printf.sprintf "%s: %s %d time(s)" s extra nb_call
-          else
+        | Threshold {threshold; _} ->
             let percent = 100. *. percent threshold nb_call in
             Printf.sprintf "%s: at least %3.2f%% of the time" s percent
         | _ ->

--- a/src/deadCommon.ml
+++ b/src/deadCommon.ml
@@ -84,7 +84,9 @@ let is_ghost loc =
   || loc.Lexing.pos_fname = _none || loc.Lexing.pos_fname = ""
 
 
-let check_underscore name = !Config.config.underscore || name.[0] <> '_'
+let check_underscore name =
+  let state = State.get_current () in
+  state.config.underscore || name.[0] <> '_'
 
 
 let hashtbl_find_list hashtbl key = Hashtbl.find_all hashtbl key
@@ -148,7 +150,7 @@ let exported ?(is_type = false) (flag : Config.Sections.main_section) loc =
   && LocHash.find_set references loc
      |> LocSet.cardinal <= Config.get_main_threshold flag
   && (is_type
-    || !Config.config.internal
+    || state.config.internal
     || fn.[String.length fn - 1] = 'i'
     || sourceunit <> Utils.unit fn
     || not (file_exists (fn ^ "i")))
@@ -466,7 +468,7 @@ let report s ~(opt: Config.Sections.opt_args_section) ?(extra = "Called") l
   else (print_newline () |> separator)
 
 
-let report_basic ?folder decs title (flag:Config.Sections.main_section) =
+let report_basic ?folder decs title (flag: Config.Sections.main_section) =
   let folder = match folder with
     | Some folder -> folder
     | None -> fun nb_call -> fun loc (builddir, path) acc ->
@@ -524,7 +526,8 @@ let report_basic ?folder decs title (flag:Config.Sections.main_section) =
       if nb_call = 0 then title
       else "ALMOST " ^ title
     in
-    report s ~opt:(!Config.config.sections.opta) l continue nb_call pretty_print reportn
+    let state = State.get_current () in
+    report s ~opt:(state.config.sections.opta) l continue nb_call pretty_print reportn
 
   in reportn 0
 

--- a/src/deadCommon.ml
+++ b/src/deadCommon.ml
@@ -140,13 +140,13 @@ let rec get_deep_desc typ =
   | t -> t
 
 
-let exported (flag : Config.basic ref) loc =
+let exported (flag : Config.main_section ref) loc =
   let state = State.get_current () in
   let fn = loc.Lexing.pos_fname in
   let sourceunit = State.File_infos.get_sourceunit state.file_infos in
-  !flag.Config.print
+  Config.is_activated !flag
   && LocHash.find_set references loc
-     |> LocSet.cardinal <= !flag.Config.threshold
+     |> LocSet.cardinal <= Config.get_main_threshold !flag
   && (flag == Config.typ
     || !Config.internal
     || fn.[String.length fn - 1] = 'i'
@@ -432,20 +432,29 @@ let pretty_print_call () = let ghost = ref false in function
       ghost := true
 
 
-let percent (opt : Config.opt) base =
+let percent (opt_threshold : Config.opt_threshold) base =
   let open Config in
-  1. -. (float_of_int base) *. (1. -. opt.threshold.percentage) /. 10.
+  1. -. (float_of_int base) *. (1. -. opt_threshold.percentage) /. 10.
 
 
 (* Base pattern for reports *)
-let report s ~(opt: Config.opt) ?(extra = "Called") l continue nb_call pretty_print reporter =
+let report s ~(opt: Config.opt_section) ?(extra = "Called") l continue nb_call pretty_print reporter =
   if nb_call = 0 || l <> [] then begin
     section ~sub:(nb_call <> 0)
     @@ (if nb_call = 0 then s
-        else if Config.(opt.threshold.optional) = `Both || extra = "Called"
-        then
+        else if String.equal extra "Called" then
           Printf.sprintf "%s: %s %d time(s)" s extra nb_call
-        else Printf.sprintf "%s: at least %3.2f%% of the time" s (100. *. percent opt nb_call));
+        else match opt with
+        | Threshold {threshold; _} ->
+          if threshold.optional = `Both || extra = "Called"
+          then
+            Printf.sprintf "%s: %s %d time(s)" s extra nb_call
+          else
+            let percent = 100. *. percent threshold nb_call in
+            Printf.sprintf "%s: at least %3.2f%% of the time" s percent
+        | _ ->
+            (* TODO: better error handling *)
+            failwith "Trying to report subsections but not threshold is found");
     List.iter pretty_print l;
     if continue nb_call then
       (if l <> [] then print_endline "--------" else ()) |> print_newline |> print_newline
@@ -454,7 +463,7 @@ let report s ~(opt: Config.opt) ?(extra = "Called") l continue nb_call pretty_pr
   else (print_newline () |> separator)
 
 
-let report_basic ?folder decs title (flag:Config.basic) =
+let report_basic ?folder decs title (flag:Config.main_section) =
   let folder = match folder with
     | Some folder -> folder
     | None -> fun nb_call -> fun loc (builddir, path) acc ->
@@ -497,17 +506,17 @@ let report_basic ?folder decs title (flag:Config.basic) =
       if change fn then print_newline ();
       prloc ~fn loc;
       print_string path;
-      if call_sites <> [] && flag.Config.call_sites then
+      if call_sites <> [] && Config.call_sites_activated flag then
         print_string "    Call sites:";
       print_newline ();
-      if flag.Config.call_sites then begin
+      if Config.call_sites_activated flag then begin
         List.fast_sort compare call_sites
         |> List.iter (pretty_print_call ());
         if nb_call <> 0 then print_newline ()
       end
     in
 
-    let continue nb_call = nb_call < flag.Config.threshold in
+    let continue nb_call = nb_call < Config.get_main_threshold flag in
     let s =
       if nb_call = 0 then title
       else "ALMOST " ^ title

--- a/src/deadCommon.ml
+++ b/src/deadCommon.ml
@@ -84,7 +84,7 @@ let is_ghost loc =
   || loc.Lexing.pos_fname = _none || loc.Lexing.pos_fname = ""
 
 
-let check_underscore name = not !Config.underscore || name.[0] <> '_'
+let check_underscore name = Config.config.underscore || name.[0] <> '_'
 
 
 let hashtbl_find_list hashtbl key = Hashtbl.find_all hashtbl key
@@ -147,8 +147,8 @@ let exported (flag : Config.main_section ref) loc =
   Config.is_activated !flag
   && LocHash.find_set references loc
      |> LocSet.cardinal <= Config.get_main_threshold !flag
-  && (flag == Config.typ
-    || !Config.internal
+  && (flag == Config.config.typ
+    || Config.config.internal
     || fn.[String.length fn - 1] = 'i'
     || sourceunit <> Utils.unit fn
     || not (file_exists (fn ^ "i")))
@@ -522,7 +522,7 @@ let report_basic ?folder decs title (flag:Config.main_section) =
       if nb_call = 0 then title
       else "ALMOST " ^ title
     in
-    report s ~opt:(!Config.opta) l continue nb_call pretty_print reportn
+    report s ~opt:(!Config.(config.opta)) l continue nb_call pretty_print reportn
 
   in reportn 0
 

--- a/src/deadCommon.ml
+++ b/src/deadCommon.ml
@@ -146,7 +146,7 @@ let exported ?(is_type = false) (flag : Config.Sections.main_section) loc =
   let state = State.get_current () in
   let fn = loc.Lexing.pos_fname in
   let sourceunit = State.File_infos.get_sourceunit state.file_infos in
-  Config.is_activated flag
+  Config.must_report_section flag
   && LocHash.find_set references loc
      |> LocSet.cardinal <= Config.get_main_threshold flag
   && (is_type
@@ -511,10 +511,10 @@ let report_basic ?folder decs title (flag: Config.Sections.main_section) =
       if change fn then print_newline ();
       prloc ~fn loc;
       print_string path;
-      if call_sites <> [] && Config.call_sites_activated flag then
+      if call_sites <> [] && Config.must_report_call_sites flag then
         print_string "    Call sites:";
       print_newline ();
-      if Config.call_sites_activated flag then begin
+      if Config.must_report_call_sites flag then begin
         List.fast_sort compare call_sites
         |> List.iter (pretty_print_call ());
         if nb_call <> 0 then print_newline ()

--- a/src/deadLexiFi.ml
+++ b/src/deadLexiFi.ml
@@ -118,12 +118,13 @@ let () =
 
   DeadLexiFi.prepare_report :=
     (fun decs ->
+     let sections = !Config.config.sections in
       List.iter
         (fun (strin, pos) ->
           hashtbl_find_list str strin
           |> List.iter
             (fun loc ->
-              if exported !Config.config.exported loc then
+              if exported sections.exported_values loc then
                 LocHash.add_set references loc pos
             )
         )
@@ -163,7 +164,7 @@ let () =
             else get_type s (pos - 1)
           in
           List.iter
-            ( if exported ~is_type:true !Config.config.typ loc then LocHash.add_set references loc
+            ( if exported ~is_type:true sections.types loc then LocHash.add_set references loc
               else ignore
             )
             (hashtbl_find_list dyn_used (get_type path (String.length path - 1)))

--- a/src/deadLexiFi.ml
+++ b/src/deadLexiFi.ml
@@ -118,7 +118,8 @@ let () =
 
   DeadLexiFi.prepare_report :=
     (fun decs ->
-     let sections = !Config.config.sections in
+      let state = State.get_current () in
+      let sections = state.config.sections in
       List.iter
         (fun (strin, pos) ->
           hashtbl_find_list str strin

--- a/src/deadLexiFi.ml
+++ b/src/deadLexiFi.ml
@@ -123,7 +123,7 @@ let () =
           hashtbl_find_list str strin
           |> List.iter
             (fun loc ->
-              if exported DeadFlag.exported loc then
+              if exported Config.exported loc then
                 LocHash.add_set references loc pos
             )
         )
@@ -163,7 +163,7 @@ let () =
             else get_type s (pos - 1)
           in
           List.iter
-            ( if exported DeadFlag.typ loc then LocHash.add_set references loc
+            ( if exported Config.typ loc then LocHash.add_set references loc
               else ignore
             )
             (hashtbl_find_list dyn_used (get_type path (String.length path - 1)))

--- a/src/deadLexiFi.ml
+++ b/src/deadLexiFi.ml
@@ -123,7 +123,7 @@ let () =
           hashtbl_find_list str strin
           |> List.iter
             (fun loc ->
-              if exported Config.exported loc then
+              if exported Config.config.exported loc then
                 LocHash.add_set references loc pos
             )
         )
@@ -163,7 +163,7 @@ let () =
             else get_type s (pos - 1)
           in
           List.iter
-            ( if exported Config.typ loc then LocHash.add_set references loc
+            ( if exported Config.config.typ loc then LocHash.add_set references loc
               else ignore
             )
             (hashtbl_find_list dyn_used (get_type path (String.length path - 1)))

--- a/src/deadLexiFi.ml
+++ b/src/deadLexiFi.ml
@@ -123,7 +123,7 @@ let () =
           hashtbl_find_list str strin
           |> List.iter
             (fun loc ->
-              if exported Config.config.exported loc then
+              if exported !Config.config.exported loc then
                 LocHash.add_set references loc pos
             )
         )
@@ -163,7 +163,7 @@ let () =
             else get_type s (pos - 1)
           in
           List.iter
-            ( if exported Config.config.typ loc then LocHash.add_set references loc
+            ( if exported ~is_type:true !Config.config.typ loc then LocHash.add_set references loc
               else ignore
             )
             (hashtbl_find_list dyn_used (get_type path (String.length path - 1)))

--- a/src/deadMod.ml
+++ b/src/deadMod.ml
@@ -86,9 +86,5 @@ let expr m = match m.mod_desc with
                 (********   WRAPPING  ********)
 
 let expr m =
-  let sections = !Config.config.sections in
-  if [@warning "-44"]
-    Config.has_activated [sections.exported_values; sections.types; sections.methods]
-  then
-    expr m
+  if [@warning "-44"] Config.has_main_section_activated () then expr m
   else ()

--- a/src/deadMod.ml
+++ b/src/deadMod.ml
@@ -70,9 +70,9 @@ let expr m = match m.mod_desc with
         let is_obj = String.contains x '#' in
         let is_type = not is_obj && DeadType.is_type x in
         let relevant_report_enabled =
-          if is_obj then Config.(is_activated !obj)
-          else if is_type then exported Config.typ loc
-          else exported Config.exported loc
+          if is_obj then Config.(is_activated !(config.obj))
+          else if is_type then exported Config.config.typ loc
+          else exported Config.config.exported loc
         in
         let value_is_expected_by_modtype = List.mem x l1 || l1 = [] in
         if value_is_expected_by_modtype && relevant_report_enabled then
@@ -86,6 +86,6 @@ let expr m = match m.mod_desc with
 
 let expr m =
   if [@warning "-44"]
-  Config.(has_activated [!exported; !typ; !obj]) then
+  Config.(has_activated [!(config.exported); !(config.typ); !(config.obj)]) then
     expr m
   else ()

--- a/src/deadMod.ml
+++ b/src/deadMod.ml
@@ -70,9 +70,9 @@ let expr m = match m.mod_desc with
         let is_obj = String.contains x '#' in
         let is_type = not is_obj && DeadType.is_type x in
         let relevant_report_enabled =
-          if is_obj then !DeadFlag.obj.DeadFlag.print
-          else if is_type then exported DeadFlag.typ loc
-          else exported DeadFlag.exported loc
+          if is_obj then !Config.obj.Config.print
+          else if is_type then exported Config.typ loc
+          else exported Config.exported loc
         in
         let value_is_expected_by_modtype = List.mem x l1 || l1 = [] in
         if value_is_expected_by_modtype && relevant_report_enabled then
@@ -86,6 +86,6 @@ let expr m = match m.mod_desc with
 
 let expr m =
   if [@warning "-44"]
-  DeadFlag.(!exported.print || !typ.print || !obj.print) then
+  Config.(!exported.print || !typ.print || !obj.print) then
     expr m
   else ()

--- a/src/deadMod.ml
+++ b/src/deadMod.ml
@@ -70,9 +70,10 @@ let expr m = match m.mod_desc with
         let is_obj = String.contains x '#' in
         let is_type = not is_obj && DeadType.is_type x in
         let relevant_report_enabled =
-          if is_obj then Config.(is_activated !config.obj)
-          else if is_type then exported ~is_type !Config.config.typ loc
-          else exported !Config.config.exported loc
+          let sections = !Config.config.sections in
+          if is_obj then Config.is_activated sections.methods
+          else if is_type then exported ~is_type sections.types loc
+          else exported sections.exported_values loc
         in
         let value_is_expected_by_modtype = List.mem x l1 || l1 = [] in
         if value_is_expected_by_modtype && relevant_report_enabled then
@@ -85,7 +86,9 @@ let expr m = match m.mod_desc with
                 (********   WRAPPING  ********)
 
 let expr m =
+  let sections = !Config.config.sections in
   if [@warning "-44"]
-  Config.(has_activated [!config.exported; !config.typ; !config.obj]) then
+    Config.has_activated [sections.exported_values; sections.types; sections.methods]
+  then
     expr m
   else ()

--- a/src/deadMod.ml
+++ b/src/deadMod.ml
@@ -70,7 +70,7 @@ let expr m = match m.mod_desc with
         let is_obj = String.contains x '#' in
         let is_type = not is_obj && DeadType.is_type x in
         let relevant_report_enabled =
-          if is_obj then !Config.obj.Config.print
+          if is_obj then Config.(is_activated !obj)
           else if is_type then exported Config.typ loc
           else exported Config.exported loc
         in
@@ -86,6 +86,6 @@ let expr m = match m.mod_desc with
 
 let expr m =
   if [@warning "-44"]
-  Config.(!exported.print || !typ.print || !obj.print) then
+  Config.(has_activated [!exported; !typ; !obj]) then
     expr m
   else ()

--- a/src/deadMod.ml
+++ b/src/deadMod.ml
@@ -70,9 +70,9 @@ let expr m = match m.mod_desc with
         let is_obj = String.contains x '#' in
         let is_type = not is_obj && DeadType.is_type x in
         let relevant_report_enabled =
-          if is_obj then Config.(is_activated !(config.obj))
-          else if is_type then exported Config.config.typ loc
-          else exported Config.config.exported loc
+          if is_obj then Config.(is_activated !config.obj)
+          else if is_type then exported ~is_type !Config.config.typ loc
+          else exported !Config.config.exported loc
         in
         let value_is_expected_by_modtype = List.mem x l1 || l1 = [] in
         if value_is_expected_by_modtype && relevant_report_enabled then
@@ -86,6 +86,6 @@ let expr m = match m.mod_desc with
 
 let expr m =
   if [@warning "-44"]
-  Config.(has_activated [!(config.exported); !(config.typ); !(config.obj)]) then
+  Config.(has_activated [!config.exported; !config.typ; !config.obj]) then
     expr m
   else ()

--- a/src/deadMod.ml
+++ b/src/deadMod.ml
@@ -72,7 +72,7 @@ let expr m = match m.mod_desc with
         let relevant_report_enabled =
           let state = State.get_current () in
           let sections = state.config.sections in
-          if is_obj then Config.is_activated sections.methods
+          if is_obj then Config.must_report_section sections.methods
           else if is_type then exported ~is_type sections.types loc
           else exported sections.exported_values loc
         in
@@ -88,6 +88,6 @@ let expr m = match m.mod_desc with
 
 let expr m =
   let state = State.get_current () in
-  if [@warning "-44"] Config.has_main_section_activated state.config then
+  if [@warning "-44"] Config.must_report_main state.config then
     expr m
   else ()

--- a/src/deadMod.ml
+++ b/src/deadMod.ml
@@ -70,7 +70,8 @@ let expr m = match m.mod_desc with
         let is_obj = String.contains x '#' in
         let is_type = not is_obj && DeadType.is_type x in
         let relevant_report_enabled =
-          let sections = !Config.config.sections in
+          let state = State.get_current () in
+          let sections = state.config.sections in
           if is_obj then Config.is_activated sections.methods
           else if is_type then exported ~is_type sections.types loc
           else exported sections.exported_values loc
@@ -86,5 +87,7 @@ let expr m = match m.mod_desc with
                 (********   WRAPPING  ********)
 
 let expr m =
-  if [@warning "-44"] Config.has_main_section_activated () then expr m
+  let state = State.get_current () in
+  if [@warning "-44"] Config.has_main_section_activated state.config then
+    expr m
   else ()

--- a/src/deadObj.ml
+++ b/src/deadObj.ml
@@ -474,7 +474,7 @@ let report () =
     else acc
   in
 
-  report_basic ~folder decs "UNUSED METHODS" !DeadFlag.obj
+  report_basic ~folder decs "UNUSED METHODS" !Config.obj
 
 
 
@@ -482,7 +482,7 @@ let report () =
 
 
 let wrap f x =
-  if !DeadFlag.obj.print then f x else ()
+  if !Config.obj.print then f x else ()
 
 let collect_export path u stock ?obj ?cltyp loc =
   wrap (collect_export path u stock ~obj ~cltyp) loc

--- a/src/deadObj.ml
+++ b/src/deadObj.ml
@@ -474,7 +474,7 @@ let report () =
     else acc
   in
 
-  report_basic ~folder decs "UNUSED METHODS" !Config.obj
+  report_basic ~folder decs "UNUSED METHODS" !Config.(config.obj)
 
 
 
@@ -482,7 +482,7 @@ let report () =
 
 
 let wrap f x =
-  if Config.(is_activated !obj) then f x else ()
+  if Config.(is_activated !(config.obj)) then f x else ()
 
 let collect_export path u stock ?obj ?cltyp loc =
   wrap (collect_export path u stock ~obj ~cltyp) loc

--- a/src/deadObj.ml
+++ b/src/deadObj.ml
@@ -484,7 +484,7 @@ let report () =
 
 let wrap f x =
   let state = State.get_current () in
-  if Config.is_activated state.config.sections.methods then
+  if Config.must_report_section state.config.sections.methods then
     f x
   else ()
 

--- a/src/deadObj.ml
+++ b/src/deadObj.ml
@@ -474,7 +474,7 @@ let report () =
     else acc
   in
 
-  report_basic ~folder decs "UNUSED METHODS" !Config.(config.obj)
+  report_basic ~folder decs "UNUSED METHODS" !Config.config.obj
 
 
 
@@ -482,7 +482,7 @@ let report () =
 
 
 let wrap f x =
-  if Config.(is_activated !(config.obj)) then f x else ()
+  if Config.(is_activated !config.obj) then f x else ()
 
 let collect_export path u stock ?obj ?cltyp loc =
   wrap (collect_export path u stock ~obj ~cltyp) loc

--- a/src/deadObj.ml
+++ b/src/deadObj.ml
@@ -474,7 +474,8 @@ let report () =
     else acc
   in
 
-  report_basic ~folder decs "UNUSED METHODS" !Config.config.sections.methods
+  let state = State.get_current () in
+  report_basic ~folder decs "UNUSED METHODS" state.config.sections.methods
 
 
 
@@ -482,7 +483,10 @@ let report () =
 
 
 let wrap f x =
-  if Config.(is_activated !config.sections.methods) then f x else ()
+  let state = State.get_current () in
+  if Config.is_activated state.config.sections.methods then
+    f x
+  else ()
 
 let collect_export path u stock ?obj ?cltyp loc =
   wrap (collect_export path u stock ~obj ~cltyp) loc

--- a/src/deadObj.ml
+++ b/src/deadObj.ml
@@ -482,7 +482,7 @@ let report () =
 
 
 let wrap f x =
-  if !Config.obj.print then f x else ()
+  if Config.(is_activated !obj) then f x else ()
 
 let collect_export path u stock ?obj ?cltyp loc =
   wrap (collect_export path u stock ~obj ~cltyp) loc

--- a/src/deadObj.ml
+++ b/src/deadObj.ml
@@ -474,7 +474,7 @@ let report () =
     else acc
   in
 
-  report_basic ~folder decs "UNUSED METHODS" !Config.config.obj
+  report_basic ~folder decs "UNUSED METHODS" !Config.config.sections.methods
 
 
 
@@ -482,7 +482,7 @@ let report () =
 
 
 let wrap f x =
-  if Config.(is_activated !config.obj) then f x else ()
+  if Config.(is_activated !config.sections.methods) then f x else ()
 
 let collect_export path u stock ?obj ?cltyp loc =
   wrap (collect_export path u stock ~obj ~cltyp) loc

--- a/src/deadType.ml
+++ b/src/deadType.ml
@@ -179,7 +179,7 @@ let report () =
 
 let wrap f x =
   let state = State.get_current () in
-  if Config.is_activated state.config.sections.types then
+  if Config.must_report_section state.config.sections.types then
     f x
   else ()
 

--- a/src/deadType.ml
+++ b/src/deadType.ml
@@ -102,7 +102,7 @@ let collect_references loc exp_loc =
 (* Look for bad style typing *)
 let rec check_style t loc =
   let state = State.get_current() in
-  if !Config.(config.style).opt_arg then
+  if !Config.config.style.opt_arg then
     match get_deep_desc t with
       | Tarrow (lab, _, t, _) -> begin
           match lab with
@@ -168,13 +168,13 @@ let tstr typ =
 
 
 let report () =
-  report_basic decs "UNUSED CONSTRUCTORS/RECORD FIELDS" !Config.(config.typ)
+  report_basic decs "UNUSED CONSTRUCTORS/RECORD FIELDS" !Config.config.typ
 
 
                 (********   WRAPPING  ********)
 
 let wrap f x =
-  if Config.(is_activated !(config.typ)) then f x else ()
+  if Config.(is_activated !config.typ) then f x else ()
 
 let collect_export path u stock t = wrap (collect_export path u stock) t
 let tstr typ = wrap tstr typ

--- a/src/deadType.ml
+++ b/src/deadType.ml
@@ -102,7 +102,7 @@ let collect_references loc exp_loc =
 (* Look for bad style typing *)
 let rec check_style t loc =
   let state = State.get_current() in
-  if !Config.config.style.opt_arg then
+  if !Config.config.sections.style.opt_arg then
     match get_deep_desc t with
       | Tarrow (lab, _, t, _) -> begin
           match lab with
@@ -168,13 +168,16 @@ let tstr typ =
 
 
 let report () =
-  report_basic decs "UNUSED CONSTRUCTORS/RECORD FIELDS" !Config.config.typ
+  report_basic
+    decs
+    "UNUSED CONSTRUCTORS/RECORD FIELDS"
+    !Config.config.sections.types
 
 
                 (********   WRAPPING  ********)
 
 let wrap f x =
-  if Config.(is_activated !config.typ) then f x else ()
+  if Config.(is_activated !config.sections.types) then f x else ()
 
 let collect_export path u stock t = wrap (collect_export path u stock) t
 let tstr typ = wrap tstr typ

--- a/src/deadType.ml
+++ b/src/deadType.ml
@@ -173,7 +173,7 @@ let report () = report_basic decs "UNUSED CONSTRUCTORS/RECORD FIELDS" !Config.ty
                 (********   WRAPPING  ********)
 
 let wrap f x =
-  if Config.(!typ.print) then f x else ()
+  if Config.(is_activated !typ) then f x else ()
 
 let collect_export path u stock t = wrap (collect_export path u stock) t
 let tstr typ = wrap tstr typ

--- a/src/deadType.ml
+++ b/src/deadType.ml
@@ -102,7 +102,7 @@ let collect_references loc exp_loc =
 (* Look for bad style typing *)
 let rec check_style t loc =
   let state = State.get_current() in
-  if !DeadFlag.style.DeadFlag.opt_arg then
+  if !Config.style.Config.opt_arg then
     match get_deep_desc t with
       | Tarrow (lab, _, t, _) -> begin
           match lab with
@@ -167,13 +167,13 @@ let tstr typ =
     | _ -> ()
 
 
-let report () = report_basic decs "UNUSED CONSTRUCTORS/RECORD FIELDS" !DeadFlag.typ
+let report () = report_basic decs "UNUSED CONSTRUCTORS/RECORD FIELDS" !Config.typ
 
 
                 (********   WRAPPING  ********)
 
 let wrap f x =
-  if DeadFlag.(!typ.print) then f x else ()
+  if Config.(!typ.print) then f x else ()
 
 let collect_export path u stock t = wrap (collect_export path u stock) t
 let tstr typ = wrap tstr typ

--- a/src/deadType.ml
+++ b/src/deadType.ml
@@ -102,7 +102,7 @@ let collect_references loc exp_loc =
 (* Look for bad style typing *)
 let rec check_style t loc =
   let state = State.get_current() in
-  if !Config.config.sections.style.opt_arg then
+  if state.config.sections.style.opt_arg then
     match get_deep_desc t with
       | Tarrow (lab, _, t, _) -> begin
           match lab with
@@ -168,16 +168,20 @@ let tstr typ =
 
 
 let report () =
+  let state = State.get_current () in
   report_basic
     decs
     "UNUSED CONSTRUCTORS/RECORD FIELDS"
-    !Config.config.sections.types
+    state.config.sections.types
 
 
                 (********   WRAPPING  ********)
 
 let wrap f x =
-  if Config.(is_activated !config.sections.types) then f x else ()
+  let state = State.get_current () in
+  if Config.is_activated state.config.sections.types then
+    f x
+  else ()
 
 let collect_export path u stock t = wrap (collect_export path u stock) t
 let tstr typ = wrap tstr typ

--- a/src/deadType.ml
+++ b/src/deadType.ml
@@ -102,7 +102,7 @@ let collect_references loc exp_loc =
 (* Look for bad style typing *)
 let rec check_style t loc =
   let state = State.get_current() in
-  if !Config.style.Config.opt_arg then
+  if !Config.(config.style).opt_arg then
     match get_deep_desc t with
       | Tarrow (lab, _, t, _) -> begin
           match lab with
@@ -167,13 +167,14 @@ let tstr typ =
     | _ -> ()
 
 
-let report () = report_basic decs "UNUSED CONSTRUCTORS/RECORD FIELDS" !Config.typ
+let report () =
+  report_basic decs "UNUSED CONSTRUCTORS/RECORD FIELDS" !Config.(config.typ)
 
 
                 (********   WRAPPING  ********)
 
 let wrap f x =
-  if Config.(is_activated !typ) then f x else ()
+  if Config.(is_activated !(config.typ)) then f x else ()
 
 let collect_export path u stock t = wrap (collect_export path u stock) t
 let tstr typ = wrap tstr typ

--- a/src/state/state.ml
+++ b/src/state/state.ml
@@ -1,14 +1,17 @@
 module File_infos = File_infos
 
-type t = {
-  file_infos : File_infos.t;
-}
+type t =
+  { config : Config.t
+  ; file_infos : File_infos.t
+  }
 
-let empty = {file_infos = File_infos.empty}
+let init config =
+  { config
+  ; file_infos = File_infos.empty
+  }
 
-let init cmti_file =
-  let file_infos = File_infos.init cmti_file in
-  Result.map (fun file_infos -> {file_infos}) file_infos
+let update_config config state =
+  {state with config}
 
 let change_file state cmti_file =
   let file_infos = state.file_infos in
@@ -21,12 +24,16 @@ let change_file state cmti_file =
     Result.ok state
   else if equal_no_ext file_infos.cmti_file cmti_file then
     let file_infos = File_infos.change_file file_infos cmti_file in
-    Result.map (fun file_infos -> {file_infos}) file_infos
+    Result.map (fun file_infos -> {state with file_infos}) file_infos
   else
-    init cmti_file
+    let file_infos = File_infos.init cmti_file in
+    Result.map (fun file_infos -> {state with file_infos}) file_infos
 
 (** Analysis' state *)
-let current = ref empty
+let current = ref
+    { config = Config.default_config
+    ; file_infos = File_infos.empty
+    }
 
 let get_current () = !current
 

--- a/src/state/state.mli
+++ b/src/state/state.mli
@@ -2,15 +2,16 @@
 
 module File_infos = File_infos
 
-type t = {
-  file_infos : File_infos.t; (** Info about the file being analyzed *)
-}
+type t =
+  { config : Config.t (** Configuration of the analysis *)
+  ; file_infos : File_infos.t (** Info about the file being analyzed *)
+  }
 
-val empty : t (** The empty state *)
+val init : Config.t -> t
+(** [init config] initial for an analysis configured by [config] *)
 
-val init : string -> (t, string) result
-(** [init cmti_file] initialize a state to analyze [cmti_file].
-    See [File_infos.init] for error cases. *)
+val update_config : Config.t -> t -> t
+(** [update_config config state] changes the analysis configuration *)
 
 val change_file : t -> string -> (t, string) result
 (** [cahnge_file t cmti_file] prepare the analysis to move on to [cmti_file].

--- a/src/state/state.mli
+++ b/src/state/state.mli
@@ -8,13 +8,13 @@ type t =
   }
 
 val init : Config.t -> t
-(** [init config] initial for an analysis configured by [config] *)
+(** [init config] initial state for an analysis configured by [config] *)
 
 val update_config : Config.t -> t -> t
 (** [update_config config state] changes the analysis configuration *)
 
 val change_file : t -> string -> (t, string) result
-(** [cahnge_file t cmti_file] prepare the analysis to move on to [cmti_file].
+(** [change_file t cmti_file] prepare the analysis to move on to [cmti_file].
     See [File_infos.change_file] for error cases. *)
 
 val get_current : unit -> t

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -8,3 +8,4 @@ let remove_pp fn =
 let unit fn =
   Filename.remove_extension (Filename.basename fn)
 
+module StringSet = Set.Make(String)

--- a/src/utils.mli
+++ b/src/utils.mli
@@ -1,3 +1,5 @@
 val remove_pp : string -> string
 
 val unit : string -> string
+
+module StringSet : Set.S with type elt = String.t


### PR DESCRIPTION
This is a significant change and part of an even larger refactor planned (https://github.com/LexiFi/dead_code_analyzer/issues/43).

## Key changes
### Introducing the `Config` module
Configuration related code is now contained in its own module (and submodule `Sections`). With this, it will be easier to debug the configuration of the analysis when necessary (debugging facilities such as pretty printing are planned for later work).

This module provides an immutable API with `private` types, ensuring there is no risk of an involuntary update of the configuration. There are only 2 ways to obtain a configuration : either by using the `Config.default_config` or by parsing the command line by using `Config.parse_cli ()`.
The only updatable field is `sections.style` by using the `Config.update_style` function. This is necessary for now because the analysis must not track stylistic issues when processing the paths passed to the `--references` command line argument [^style_and_ref].

[^style_and_ref]: I think this rule should be changed to still track stylistic issues on "reference" paths. The idea behind `--references` was to not track new declarations (be it values, types, methods or optional arguments). This idea does not contradict the identification of stylistic issues.

The `State.t` has been updated to hold the configuration. The analysis state can only be initialized by providing a configuration [^empty_state].
Rather than accessing the different configuration information through globally accessible `ref`s, the analyzer would read the appropriate `state.config` fields.

[^empty_state]: A default state exists and provides the `default_config`, but is not explicitly exposed in the API. It is only used as the initial value for the `current` state before any `State.update` happened. 

### Simplifying the command line arguments order

Previously,  the following command would have meant "analyze path1 for the unused exported values only and path2 for both the unused exported values and the unused methods" : 
`dead_code_analyzer --nothing -E all path1 -M all path2`
Now all the paths are gathered together before any analysis is run, so the configuration is the same for all files. Hence, the above command now means "analyze path1 and path2 for unused exported values and methods". Consequently, one could prefer using its "normalized" form instead : 
 `dead_code_analyzer --nothing -E all -M all path1 path2`

Disabling complex command line semantics is voluntary. It could be re-enabled in the future if there is a request for it but for now, the simplified meaning should lead to clearer documentation and easier maintenance.


## Note

This change will facilitate the 5.3 update, which would require to know which `.cm*` files are provided to find out some location information. (The 5.3 update currently fails on cases like https://github.com/LexiFi/dead_code_analyzer/pull/53).

In OCaml 5.3, the `cmt_infos.cmt_value_dependencies` has been replaced by `cmt_infos.cmt_declaration_dependencies` which uses `Shape.Uid.t` instead of `Types.value_description`. This change of type makes location harder to get because they were directly accessible in `Types.value_description` but are inexistant in `Shape.Uid.t`.
The analysis relies on locations. Finding an uid's location can be done using `cmt_infos.cmt_uid_to_decl` but, as described in [Shape.mli](https://github.com/ocaml/ocaml/blob/5.3.0/typing/shape.mli), one needs to read the `.cmt` of external units to find the location of corresponding "external" uids (although they appear in the `cmt_declaration_dependencies`).

Thus, knowing which files are given to the tool will indicate which in files "external" uids can be looked for, and the analyzer will be able to correctly associate locations like it does in OCaml 5.2