### PR TITLE
Store cmi and cmt paths only in the config

### DIFF
--- a/src/config/config.mli
+++ b/src/config/config.mli
@@ -22,10 +22,12 @@ type t = private
   ; internal : bool (** Keep track of internal uses for exported values *)
   ; underscore : bool (** Keep track of elements with names starting with [_] *)
   ; paths_to_analyze : Utils.StringSet.t
-      (** Paths found in the command line and considered for analysis *)
-  ; excluded_paths : Utils.StringSet.t (** Paths to exclude from the analysis *)
+      (** Cmi and cmt filepaths found by exploring the paths provided in the
+          command line and considered for analysis *)
+  ; excluded_paths : Utils.StringSet.t
+      (** Cmi and cmt filepaths to exclude from the analysis *)
   ; references_paths : Utils.StringSet.t
-      (** Paths to explore for references only *)
+      (** Cmi and cmt filepaths to explore for references only *)
   ; sections : Sections.t (** Config for the different report sections *)
   }
 

--- a/src/deadCode.ml
+++ b/src/deadCode.ml
@@ -342,18 +342,6 @@ let collect_references =                          (* Tast_mapper *)
                 type_declaration
               }
 
-(* Checks the nature of the file *)
-let kind fn =
-  let state = State.get_current () in
-  if not (Sys.file_exists fn) then begin
-    prerr_endline ("Warning: '" ^ fn ^ "' not found");
-    `Ignore
-  end else if Config.is_excluded fn state.config then `Ignore
-  else if Sys.is_directory fn then `Dir
-  else if Filename.check_suffix fn ".cmi" then `Cmi
-  else if Filename.check_suffix fn ".cmt" then `Cmt
-  else `Ignore
-
 
 let regabs state =
   let fn = State.File_infos.get_sourcepath state.State.file_infos in
@@ -458,7 +446,8 @@ let rec load_file fn state =
         (* TODO: stateful computations should take and return the state when possible *)
         state
   in
-  match kind fn with
+  let exclude filepath = Config.is_excluded filepath state.State.config in
+  match Utils.kind ~exclude fn with
   | `Cmi when !DeadCommon.declarations ->
       last_loc := Lexing.dummy_pos;
       if state.State.config.verbose then Printf.eprintf "Scanning %s\n%!" fn;

--- a/src/deadCode.ml
+++ b/src/deadCode.ml
@@ -434,7 +434,7 @@ let eof loc_dep =
 
 
 (* Starting point *)
-let rec load_file fn state =
+let load_file fn state =
   let init_and_continue state fn f =
     match State.change_file state fn with
     | Error msg ->
@@ -491,13 +491,9 @@ let rec load_file fn state =
       )
 
   | Dir ->
-      let next = Sys.readdir fn in
-      Array.sort compare next;
-      Array.fold_left
-        (fun state s -> load_file (fn ^ "/" ^ s) state)
-        state
-        next
-      (* else Printf.eprintf "skipping directory %s\n" fn *)
+      (* TODO : better error handling *)
+      failwith ("Internal error : Unexpected directory "
+                ^ fn ^ ". Only .cmi and .cmt are expected")
 
   | _ -> state
 

--- a/src/deadCommon.ml
+++ b/src/deadCommon.ml
@@ -127,7 +127,7 @@ let find_path fn l =
   List.find (is_sub_path ~sep fn) l
 
 let find_abspath fn =
-  find_path fn (hashtbl_find_list abspath (Utils.unit fn))
+  find_path fn (hashtbl_find_list abspath (Utils.Filepath.unit fn))
 
 let file_exists fn =
   match find_abspath fn with
@@ -152,7 +152,7 @@ let exported ?(is_type = false) (flag : Config.Sections.main_section) loc =
   && (is_type
     || state.config.internal
     || fn.[String.length fn - 1] = 'i'
-    || sourceunit <> Utils.unit fn
+    || sourceunit <> Utils.Filepath.unit fn
     || not (file_exists (fn ^ "i")))
 
 
@@ -362,7 +362,7 @@ module VdNode = struct
         if not (LocSet.is_empty worklist) then
           let loc = LocSet.choose worklist in
           let wl = LocSet.remove loc worklist in
-          if Utils.unit loc.Lexing.pos_fname <> sourceunit then
+          if Utils.Filepath.unit loc.Lexing.pos_fname <> sourceunit then
             List.iter (LocHash.remove parents) loc_list
           else begin
             LocHash.replace met loc ();
@@ -394,7 +394,7 @@ let export ?(sep = ".") path u stock id loc =
     will create value definitions whose location is in set.mli
   *)
   if not loc.Location.loc_ghost
-  && (u = Utils.unit loc.Location.loc_start.Lexing.pos_fname || u == _include)
+  && (u = Utils.Filepath.unit loc.Location.loc_start.Lexing.pos_fname || u == _include)
   && check_underscore (Ident.name id) then
     let state = State.get_current () in
     let builddir = State.File_infos.get_builddir state.file_infos in

--- a/src/state/file_infos.ml
+++ b/src/state/file_infos.ml
@@ -50,13 +50,8 @@ let init_from_cmt cmt_file =
 
 
 let sourcefname_of_cmi_infos cmi_unit cmi_infos =
-  (* Use lowercased units because dune wrapped lib's module units follow the
-     pattern : `<lib>__<Captilized_module>` while the original module unit may
-     not be capitalized.
-  *)
-  let cmi_unit = String.lowercase_ascii cmi_unit in
   let candidate_of_fname fname =
-    let src_unit = Utils.Filepath.unit fname |> String.lowercase_ascii in
+    let src_unit = Utils.Filepath.unit fname in
     if String.equal src_unit cmi_unit then
       `Identical fname
     else if String.ends_with ~suffix:src_unit cmi_unit then
@@ -199,7 +194,8 @@ let get_builddir t =
 
 let get_sourcepath t =
   match t.sourcepath with
-  | Some sourcepath -> sourcepath
+  | Some sourcepath ->
+      sourcepath
   | None -> match t.builddir with
     | Some builddir ->
       Printf.sprintf "!!UNKNOWN_SOURCEPATH_IN<%s>_FOR_<%s>!!"

--- a/src/state/file_infos.ml
+++ b/src/state/file_infos.ml
@@ -23,7 +23,7 @@ let empty = {
 let init_from_cmt_infos cmt_infos cmt_file =
   let builddir = cmt_infos.Cmt_format.cmt_builddir in
   let sourcepath =
-    Option.map Utils.remove_pp cmt_infos.cmt_sourcefile
+    Option.map Utils.Filepath.remove_pp cmt_infos.cmt_sourcefile
     |> Option.map (Filename.concat builddir)
   in
   let modname = cmt_infos.cmt_modname in
@@ -56,7 +56,7 @@ let sourcefname_of_cmi_infos cmi_unit cmi_infos =
   *)
   let cmi_unit = String.lowercase_ascii cmi_unit in
   let candidate_of_fname fname =
-    let src_unit = Utils.unit fname |> String.lowercase_ascii in
+    let src_unit = Utils.Filepath.unit fname |> String.lowercase_ascii in
     if String.equal src_unit cmi_unit then
       `Identical fname
     else if String.ends_with ~suffix:src_unit cmi_unit then
@@ -112,7 +112,7 @@ let init_from_cmi_infos ?with_cmt cmi_infos cmi_file =
   let sourcepath =
     let sourcepath =
       (* Try to find a sourcepath in the cmi_infos *)
-      let cmi_unit = Utils.unit cmi_file in
+      let cmi_unit = Utils.Filepath.unit cmi_file in
       let sourcefname = sourcefname_of_cmi_infos cmi_unit cmi_infos in
       match sourcefname, builddir with
       | Some fname, Some builddir -> Some (Filename.concat builddir fname)
@@ -209,7 +209,7 @@ let get_sourcepath t =
 
 let get_sourceunit t =
   match t.sourcepath with
-  | Some sourcepath -> Utils.unit sourcepath
+  | Some sourcepath -> Utils.Filepath.unit sourcepath
   | None -> "!!UNKNOWN_SOURCEUNIT_FOR<" ^ t.cmti_file ^ ">!!"
 
 let get_modname t = t.modname

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -10,7 +10,7 @@ module Filepath = struct
     | _ -> filepath
 
   let unit filepath =
-    Filename.remove_extension (Filename.basename filepath)
+    Unit_info.modname_from_source filepath
 
   type kind =
     | Cmi

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -1,23 +1,34 @@
-let remove_pp filepath =
-  let ext = Filename.extension filepath in
-  let no_ext = Filename.remove_extension filepath in
-  match Filename.extension no_ext with
-  | ".pp" -> Filename.remove_extension no_ext ^ ext
-  | _ -> filepath
+module Filepath = struct
 
-let unit filepath =
-  Filename.remove_extension (Filename.basename filepath)
+  type t = string
 
-(* Checks the nature of the file *)
-let kind ~exclude filepath =
-  if exclude filepath then `Ignore
-  else if not (Sys.file_exists filepath) then (
-    prerr_endline ("Warning: '" ^ filepath ^ "' not found");
-    `Ignore
-  )
-  else if Sys.is_directory filepath then `Dir
-  else if Filename.check_suffix filepath ".cmi" then `Cmi
-  else if Filename.check_suffix filepath ".cmt" then `Cmt
-  else `Ignore
+  let remove_pp filepath =
+    let ext = Filename.extension filepath in
+    let no_ext = Filename.remove_extension filepath in
+    match Filename.extension no_ext with
+    | ".pp" -> Filename.remove_extension no_ext ^ ext
+    | _ -> filepath
+
+  let unit filepath =
+    Filename.remove_extension (Filename.basename filepath)
+
+  type kind =
+    | Cmi
+    | Cmt
+    | Dir
+    | Ignore
+
+  (* Checks the nature of the file *)
+  let kind ~exclude filepath =
+    if exclude filepath then Ignore
+    else if not (Sys.file_exists filepath) then (
+      prerr_endline ("Warning: '" ^ filepath ^ "' not found");
+      Ignore
+    )
+    else if Sys.is_directory filepath then Dir
+    else if Filename.check_suffix filepath ".cmi" then Cmi
+    else if Filename.check_suffix filepath ".cmt" then Cmt
+    else Ignore
+end
 
 module StringSet = Set.Make(String)

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -1,11 +1,23 @@
-let remove_pp fn =
-  let ext = Filename.extension fn in
-  let no_ext = Filename.remove_extension fn in
+let remove_pp filepath =
+  let ext = Filename.extension filepath in
+  let no_ext = Filename.remove_extension filepath in
   match Filename.extension no_ext with
   | ".pp" -> Filename.remove_extension no_ext ^ ext
-  | _ -> fn
+  | _ -> filepath
 
-let unit fn =
-  Filename.remove_extension (Filename.basename fn)
+let unit filepath =
+  Filename.remove_extension (Filename.basename filepath)
+
+(* Checks the nature of the file *)
+let kind ~exclude filepath =
+  if exclude filepath then `Ignore
+  else if not (Sys.file_exists filepath) then (
+    prerr_endline ("Warning: '" ^ filepath ^ "' not found");
+    `Ignore
+  )
+  else if Sys.is_directory filepath then `Dir
+  else if Filename.check_suffix filepath ".cmi" then `Cmi
+  else if Filename.check_suffix filepath ".cmt" then `Cmt
+  else `Ignore
 
 module StringSet = Set.Make(String)

--- a/src/utils.mli
+++ b/src/utils.mli
@@ -1,14 +1,25 @@
-val remove_pp : string -> string
-(** [remove_pp filepath] removes the `.pp` extension (if it exists) from
-    [filepath]. Eg. [remove_pp "dir/foo.pp.ml" = "dir/foo.ml"] *)
+module Filepath : sig
 
-val unit : string -> string
-(** [unit filepath] estimates the compilation unit of [filepath] *)
+  type t = string
 
-val kind : exclude:(string -> bool) -> string -> [> `Cmi | `Cmt | `Dir | `Ignore ]
-(** [kind ~exclude filepath] returns the kind of [filepath].
-    If [exclude filepath = true], [filepath] does not exists, or [filepath]
-    does not fit in qnother kind, then its kind is [`Ignore].
-    Other kinds are self explanatory. *)
+  val remove_pp : t -> t
+  (** [remove_pp filepath] removes the `.pp` extension (if it exists) from
+      [filepath]. Eg. [remove_pp "dir/foo.pp.ml" = "dir/foo.ml"] *)
+
+  val unit : t -> string
+  (** [unit filepath] estimates the compilation unit of [filepath] *)
+
+  type kind =
+    | Cmi (** .cmi file *)
+    | Cmt (** .cmt file *)
+    | Dir (** Directory *)
+    | Ignore (** Irrelevant for the analyzer *)
+
+  val kind : exclude:(t -> bool) -> t -> kind
+  (** [kind ~exclude filepath] returns the kind of [filepath].
+      If [exclude filepath = true], [filepath] does not exists, or [filepath]
+      does not fit in another kind, then its kind is [Ignore].
+      Other kinds are self explanatory. *)
+end
 
 module StringSet : Set.S with type elt = String.t

--- a/src/utils.mli
+++ b/src/utils.mli
@@ -1,5 +1,14 @@
 val remove_pp : string -> string
+(** [remove_pp filepath] removes the `.pp` extension (if it exists) from
+    [filepath]. Eg. [remove_pp "dir/foo.pp.ml" = "dir/foo.ml"] *)
 
 val unit : string -> string
+(** [unit filepath] estimates the compilation unit of [filepath] *)
+
+val kind : exclude:(string -> bool) -> string -> [> `Cmi | `Cmt | `Dir | `Ignore ]
+(** [kind ~exclude filepath] returns the kind of [filepath].
+    If [exclude filepath = true], [filepath] does not exists, or [filepath]
+    does not fit in qnother kind, then its kind is [`Ignore].
+    Other kinds are self explanatory. *)
 
 module StringSet : Set.S with type elt = String.t


### PR DESCRIPTION
Rather than storing the paths found in the command line arguments as-is and having the analysis do the traversal to identify cmi and cmt files, the traversal is done at configuration time. This way, the paths found in the configuration would not need to be traversed again each time some feature will want to reuse them (for 5.3).

A small change in the computation of compilation units also helps simplify the sourcepath retrieval for cmi files. It is now computed using the compiler's `Unit_info.modname_from_source`