### PR TITLE
Add doc for methods

### DIFF
--- a/check/classic/classic.exp
+++ b/check/classic/classic.exp
@@ -151,6 +151,8 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/class/class_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/coercion/coercion_lib.mli:2: obj#unused
+
 ./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#reset
 

--- a/check/classic/classic.exp
+++ b/check/classic/classic.exp
@@ -154,6 +154,8 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
 

--- a/check/classic/classic.exp
+++ b/check/classic/classic.exp
@@ -151,6 +151,9 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/class/class_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:2: unused_class#unused_method
+./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#reset
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 

--- a/check/classic/classic.exp
+++ b/check/classic/classic.exp
@@ -25,6 +25,8 @@
 ./examples/docs/exported_values/hello_world/hello_world_with_intf.mli:3: goodbye
 ./examples/docs/exported_values/hello_world/hello_world_with_intf.mli:4: world
 
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:3: internally_used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:38: internally_used_f
@@ -146,6 +148,9 @@ Nothing else to report in this section
 
 .> UNUSED METHODS:
 =================
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
 

--- a/check/classic/classic.exp
+++ b/check/classic/classic.exp
@@ -159,6 +159,8 @@ Nothing else to report in this section
 
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
 
+./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#unused
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
 

--- a/check/classic/classic.exp
+++ b/check/classic/classic.exp
@@ -148,6 +148,9 @@ Nothing else to report in this section
 
 .> UNUSED METHODS:
 =================
+./examples/docs/methods/code_constructs/class/class_bin.ml:2: unused_class#unused_method
+./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#reset
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 

--- a/check/classic/classic.exp
+++ b/check/classic/classic.exp
@@ -25,7 +25,12 @@
 ./examples/docs/exported_values/hello_world/hello_world_with_intf.mli:3: goodbye
 ./examples/docs/exported_values/hello_world/hello_world_with_intf.mli:4: world
 
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_bin.ml:2: unused_factory
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj
+
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:8: random_factory
 
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:3: internally_used
@@ -156,12 +161,18 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_bin.ml:2: unused_factory#unused_method
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_lib.mli:2: get_stack#reset
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#unused
+
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding#m
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:8: random_factory#m
 
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
@@ -587,6 +598,9 @@ Nothing else to report in this section
 ./examples/docs/exported_values/code_constructs/module/module_lib.ml:7: unit pattern unused_unexported
 
 ./examples/docs/exported_values/limitations/sigincl/sigincl_lib.ml:9: unit pattern x
+
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:3: let x = ... in x (=> useless binding)
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:12: let x = ... in x (=> useless binding)
 
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: let () = ... in ... (=> use sequence)
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: unit pattern unit_binding

--- a/check/classic/classic.exp
+++ b/check/classic/classic.exp
@@ -169,6 +169,8 @@ Nothing else to report in this section
 
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
 
+./examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_lib.mli:2: stack#reset
+
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#unused
 
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding#m

--- a/check/classic/classic.ref
+++ b/check/classic/classic.ref
@@ -156,6 +156,9 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/class/class_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:2: unused_class#unused_method
+./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#reset
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 
@@ -633,7 +636,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 542
-Success: 537
+Total: 544
+Success: 539
 Failed: 5
-Ratio: 99.0774907749%
+Ratio: 99.0808823529%

--- a/check/classic/classic.ref
+++ b/check/classic/classic.ref
@@ -153,6 +153,9 @@ Nothing else to report in this section
 
 .> UNUSED METHODS:
 =================
+./examples/docs/methods/code_constructs/class/class_bin.ml:2: unused_class#unused_method
+./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#reset
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 
@@ -628,7 +631,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 539
-Success: 534
+Total: 541
+Success: 536
 Failed: 5
-Ratio: 99.0723562152%
+Ratio: 99.0757855823%

--- a/check/classic/classic.ref
+++ b/check/classic/classic.ref
@@ -159,6 +159,8 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
 
@@ -631,7 +633,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 541
-Success: 536
+Total: 542
+Success: 537
 Failed: 5
-Ratio: 99.0757855823%
+Ratio: 99.0774907749%

--- a/check/classic/classic.ref
+++ b/check/classic/classic.ref
@@ -30,7 +30,12 @@
 ./examples/docs/exported_values/limitations/incl_same_name/oo.mli:40: new_method: Should not be detected
 ./examples/docs/exported_values/limitations/incl_same_name/oo.mli:41: public_method_label: Should not be detected
 ./examples/docs/exported_values/limitations/sigincl/sigincl_lib.mli:10: I.x: Should not be detected
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_bin.ml:2: unused_factory
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj
+
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:8: random_factory
 
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:3: internally_used
@@ -161,6 +166,9 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_bin.ml:2: unused_factory#unused_method
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_lib.mli:2: get_stack#reset
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 
@@ -168,6 +176,9 @@ Nothing else to report in this section
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#unused
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#used_by_alias: Should not be detected
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding#m: Not detected
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:8: random_factory#m
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
 
@@ -593,6 +604,9 @@ Nothing else to report in this section
 
 ./examples/docs/exported_values/limitations/sigincl/sigincl_lib.ml:9: unit pattern x
 
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:3: let x = ... in x (=> useless binding)
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:12: let x = ... in x (=> useless binding)
+
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: let () = ... in ... (=> use sequence)
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: unit pattern unit_binding
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:84: val f: ... -> (... -> ?_:_ -> ...) -> ...
@@ -640,7 +654,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 547
-Success: 541
-Failed: 6
-Ratio: 98.9031078611%
+Total: 556
+Success: 549
+Failed: 7
+Ratio: 98.7410071942%

--- a/check/classic/classic.ref
+++ b/check/classic/classic.ref
@@ -164,6 +164,8 @@ Nothing else to report in this section
 
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
 
+./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#unused
+./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#used_by_alias: Should not be detected
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
 
@@ -636,7 +638,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 544
-Success: 539
-Failed: 5
-Ratio: 99.0808823529%
+Total: 546
+Success: 540
+Failed: 6
+Ratio: 98.9010989011%

--- a/check/classic/classic.ref
+++ b/check/classic/classic.ref
@@ -156,6 +156,8 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/class/class_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/coercion/coercion_lib.mli:2: obj#unused
+
 ./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#reset
 
@@ -638,7 +640,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 546
-Success: 540
+Total: 547
+Success: 541
 Failed: 6
-Ratio: 98.9010989011%
+Ratio: 98.9031078611%

--- a/check/classic/classic.ref
+++ b/check/classic/classic.ref
@@ -30,6 +30,8 @@
 ./examples/docs/exported_values/limitations/incl_same_name/oo.mli:40: new_method: Should not be detected
 ./examples/docs/exported_values/limitations/incl_same_name/oo.mli:41: public_method_label: Should not be detected
 ./examples/docs/exported_values/limitations/sigincl/sigincl_lib.mli:10: I.x: Should not be detected
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:3: internally_used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:38: internally_used_f
@@ -151,6 +153,9 @@ Nothing else to report in this section
 
 .> UNUSED METHODS:
 =================
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
 
@@ -623,7 +628,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 536
-Success: 531
+Total: 539
+Success: 534
 Failed: 5
-Ratio: 99.0671641791%
+Ratio: 99.0723562152%

--- a/check/classic/classic.ref
+++ b/check/classic/classic.ref
@@ -174,6 +174,8 @@ Nothing else to report in this section
 
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
 
+./examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_lib.mli:2: stack#reset
+
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#unused
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#used_by_alias: Should not be detected
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding#m: Not detected
@@ -654,7 +656,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 556
-Success: 549
+Total: 557
+Success: 550
 Failed: 7
-Ratio: 98.7410071942%
+Ratio: 98.7432675045%

--- a/check/internal/internal.exp
+++ b/check/internal/internal.exp
@@ -15,6 +15,8 @@
 
 ./examples/docs/exported_values/code_constructs/module/module_lib.mli:6: M.unused
 
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:2: unused
 
@@ -101,6 +103,9 @@ Nothing else to report in this section
 
 .> UNUSED METHODS:
 =================
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
 

--- a/check/internal/internal.exp
+++ b/check/internal/internal.exp
@@ -103,6 +103,9 @@ Nothing else to report in this section
 
 .> UNUSED METHODS:
 =================
+./examples/docs/methods/code_constructs/class/class_bin.ml:2: unused_class#unused_method
+./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#reset
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 

--- a/check/internal/internal.exp
+++ b/check/internal/internal.exp
@@ -106,6 +106,9 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/class/class_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:2: unused_class#unused_method
+./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#reset
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 

--- a/check/internal/internal.exp
+++ b/check/internal/internal.exp
@@ -106,6 +106,8 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/class/class_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/coercion/coercion_lib.mli:2: obj#unused
+
 ./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#reset
 

--- a/check/internal/internal.exp
+++ b/check/internal/internal.exp
@@ -15,7 +15,12 @@
 
 ./examples/docs/exported_values/code_constructs/module/module_lib.mli:6: M.unused
 
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_bin.ml:2: unused_factory
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj
+
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:8: random_factory
 
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:2: unused
@@ -111,12 +116,18 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_bin.ml:2: unused_factory#unused_method
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_lib.mli:2: get_stack#reset
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#unused
+
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding#m
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:8: random_factory#m
 
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
@@ -542,6 +553,9 @@ Nothing else to report in this section
 ./examples/docs/exported_values/code_constructs/module/module_lib.ml:7: unit pattern unused_unexported
 
 ./examples/docs/exported_values/limitations/sigincl/sigincl_lib.ml:9: unit pattern x
+
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:3: let x = ... in x (=> useless binding)
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:12: let x = ... in x (=> useless binding)
 
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: let () = ... in ... (=> use sequence)
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: unit pattern unit_binding

--- a/check/internal/internal.exp
+++ b/check/internal/internal.exp
@@ -109,6 +109,8 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
 

--- a/check/internal/internal.exp
+++ b/check/internal/internal.exp
@@ -124,6 +124,8 @@ Nothing else to report in this section
 
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
 
+./examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_lib.mli:2: stack#reset
+
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#unused
 
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding#m

--- a/check/internal/internal.exp
+++ b/check/internal/internal.exp
@@ -114,6 +114,8 @@ Nothing else to report in this section
 
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
 
+./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#unused
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
 

--- a/check/internal/internal.ref
+++ b/check/internal/internal.ref
@@ -108,6 +108,9 @@ Nothing else to report in this section
 
 .> UNUSED METHODS:
 =================
+./examples/docs/methods/code_constructs/class/class_bin.ml:2: unused_class#unused_method
+./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#reset
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 
@@ -583,7 +586,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 497
-Success: 492
+Total: 499
+Success: 494
 Failed: 5
-Ratio: 98.9939637827%
+Ratio: 98.997995992%

--- a/check/internal/internal.ref
+++ b/check/internal/internal.ref
@@ -111,6 +111,9 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/class/class_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:2: unused_class#unused_method
+./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#reset
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 
@@ -588,7 +591,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 500
-Success: 495
+Total: 502
+Success: 497
 Failed: 5
-Ratio: 99.%
+Ratio: 99.0039840637%

--- a/check/internal/internal.ref
+++ b/check/internal/internal.ref
@@ -114,6 +114,8 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
 
@@ -586,7 +588,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 499
-Success: 494
+Total: 500
+Success: 495
 Failed: 5
-Ratio: 98.997995992%
+Ratio: 99.%

--- a/check/internal/internal.ref
+++ b/check/internal/internal.ref
@@ -20,6 +20,8 @@
 ./examples/docs/exported_values/limitations/incl_same_name/oo.mli:40: new_method: Should not be detected
 ./examples/docs/exported_values/limitations/incl_same_name/oo.mli:41: public_method_label: Should not be detected
 ./examples/docs/exported_values/limitations/sigincl/sigincl_lib.mli:10: I.x: Should not be detected
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:2: unused
 
@@ -106,6 +108,9 @@ Nothing else to report in this section
 
 .> UNUSED METHODS:
 =================
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
 
@@ -578,7 +583,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 494
-Success: 489
+Total: 497
+Success: 492
 Failed: 5
-Ratio: 98.987854251%
+Ratio: 98.9939637827%

--- a/check/internal/internal.ref
+++ b/check/internal/internal.ref
@@ -119,6 +119,8 @@ Nothing else to report in this section
 
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
 
+./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#unused
+./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#used_by_alias: Should not be detected
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
 
@@ -591,7 +593,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 502
-Success: 497
-Failed: 5
-Ratio: 99.0039840637%
+Total: 504
+Success: 498
+Failed: 6
+Ratio: 98.8095238095%

--- a/check/internal/internal.ref
+++ b/check/internal/internal.ref
@@ -111,6 +111,8 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/class/class_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/coercion/coercion_lib.mli:2: obj#unused
+
 ./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#reset
 
@@ -593,7 +595,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 504
-Success: 498
+Total: 505
+Success: 499
 Failed: 6
-Ratio: 98.8095238095%
+Ratio: 98.8118811881%

--- a/check/internal/internal.ref
+++ b/check/internal/internal.ref
@@ -129,6 +129,8 @@ Nothing else to report in this section
 
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
 
+./examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_lib.mli:2: stack#reset
+
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#unused
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#used_by_alias: Should not be detected
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding#m: Not detected
@@ -609,7 +611,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 514
-Success: 507
+Total: 515
+Success: 508
 Failed: 7
-Ratio: 98.6381322957%
+Ratio: 98.640776699%

--- a/check/internal/internal.ref
+++ b/check/internal/internal.ref
@@ -20,7 +20,12 @@
 ./examples/docs/exported_values/limitations/incl_same_name/oo.mli:40: new_method: Should not be detected
 ./examples/docs/exported_values/limitations/incl_same_name/oo.mli:41: public_method_label: Should not be detected
 ./examples/docs/exported_values/limitations/sigincl/sigincl_lib.mli:10: I.x: Should not be detected
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_bin.ml:2: unused_factory
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj
+
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:8: random_factory
 
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:2: unused
@@ -116,6 +121,9 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_bin.ml:2: unused_factory#unused_method
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_lib.mli:2: get_stack#reset
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 
@@ -123,6 +131,9 @@ Nothing else to report in this section
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#unused
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#used_by_alias: Should not be detected
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding#m: Not detected
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:8: random_factory#m
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
 
@@ -548,6 +559,9 @@ Nothing else to report in this section
 
 ./examples/docs/exported_values/limitations/sigincl/sigincl_lib.ml:9: unit pattern x
 
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:3: let x = ... in x (=> useless binding)
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:12: let x = ... in x (=> useless binding)
+
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: let () = ... in ... (=> use sequence)
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: unit pattern unit_binding
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:84: val f: ... -> (... -> ?_:_ -> ...) -> ...
@@ -595,7 +609,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 505
-Success: 499
-Failed: 6
-Ratio: 98.8118811881%
+Total: 514
+Success: 507
+Failed: 7
+Ratio: 98.6381322957%

--- a/check/threshold-1/threshold-1.exp
+++ b/check/threshold-1/threshold-1.exp
@@ -141,6 +141,8 @@
 
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:4: push_n_times
 
+./examples/docs/methods/code_constructs/object_type/object_type_bin.ml:4: push_n_times
+
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_lib.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_no_intf.mli:1: mark_used

--- a/check/threshold-1/threshold-1.exp
+++ b/check/threshold-1/threshold-1.exp
@@ -139,6 +139,8 @@
 
 ./examples/docs/methods/code_constructs/class_type/class_type_bin.ml:4: push_n_times
 
+./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:4: push_n_times
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:4: push_n_times
 
 ./examples/docs/methods/code_constructs/object_type/object_type_bin.ml:4: push_n_times
@@ -351,6 +353,9 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/class/class_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:2: unused_class#unused_method
+./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#reset
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 
@@ -419,6 +424,10 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#pop
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#push
+
+./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#peek
+./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#pop
+./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#push
 
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#pop

--- a/check/threshold-1/threshold-1.exp
+++ b/check/threshold-1/threshold-1.exp
@@ -139,6 +139,8 @@
 
 ./examples/docs/methods/code_constructs/class_type/class_type_bin.ml:4: push_n_times
 
+./examples/docs/methods/code_constructs/coercion/coercion_lib.mli:2: obj
+
 ./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:4: push_n_times
 
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:4: push_n_times
@@ -355,6 +357,8 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/class/class_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/coercion/coercion_lib.mli:2: obj#unused
+
 ./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#reset
 
@@ -428,6 +432,8 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#pop
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#push
+
+./examples/docs/methods/code_constructs/coercion/coercion_lib.mli:2: obj#used_by_requirement
 
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#pop

--- a/check/threshold-1/threshold-1.exp
+++ b/check/threshold-1/threshold-1.exp
@@ -15,7 +15,12 @@
 
 ./examples/docs/exported_values/code_constructs/module/module_lib.mli:6: M.unused
 
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_bin.ml:2: unused_factory
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj
+
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:8: random_factory
 
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:2: unused
@@ -142,6 +147,8 @@
 ./examples/docs/methods/code_constructs/coercion/coercion_lib.mli:2: obj
 
 ./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:4: push_n_times
+
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_bin.ml:4: push_n_times
 
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:4: push_n_times
 
@@ -362,12 +369,18 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_bin.ml:2: unused_factory#unused_method
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_lib.mli:2: get_stack#reset
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#unused
+
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding#m
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:8: random_factory#m
 
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
@@ -438,6 +451,10 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#pop
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#push
+
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_lib.mli:2: get_stack#peek
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_lib.mli:2: get_stack#pop
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_lib.mli:2: get_stack#push
 
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#pop
@@ -953,6 +970,9 @@ Nothing else to report in this section
 ./examples/docs/exported_values/code_constructs/module/module_lib.ml:7: unit pattern unused_unexported
 
 ./examples/docs/exported_values/limitations/sigincl/sigincl_lib.ml:9: unit pattern x
+
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:3: let x = ... in x (=> useless binding)
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:12: let x = ... in x (=> useless binding)
 
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: let () = ... in ... (=> use sequence)
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: unit pattern unit_binding

--- a/check/threshold-1/threshold-1.exp
+++ b/check/threshold-1/threshold-1.exp
@@ -137,6 +137,8 @@
 
 ./examples/docs/methods/code_constructs/class/class_bin.ml:4: push_n_times
 
+./examples/docs/methods/code_constructs/class_type/class_type_bin.ml:4: push_n_times
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:4: push_n_times
 
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used

--- a/check/threshold-1/threshold-1.exp
+++ b/check/threshold-1/threshold-1.exp
@@ -352,6 +352,8 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
 
@@ -419,6 +421,9 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#pop
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#push
+
+./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#used
+./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#used_by_child
 
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#externally_used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#internally_used

--- a/check/threshold-1/threshold-1.exp
+++ b/check/threshold-1/threshold-1.exp
@@ -135,6 +135,8 @@
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:2: hello
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:3: goodbye
 
+./examples/docs/methods/code_constructs/class/class_bin.ml:4: push_n_times
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:4: push_n_times
 
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
@@ -342,6 +344,9 @@ Nothing else to report in this section
 
 .> UNUSED METHODS:
 =================
+./examples/docs/methods/code_constructs/class/class_bin.ml:2: unused_class#unused_method
+./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#reset
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 
@@ -405,6 +410,10 @@ Nothing else to report in this section
 
 .>->  ALMOST UNUSED METHODS: Called 1 time(s):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#peek
+./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#pop
+./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#push
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#pop
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#push

--- a/check/threshold-1/threshold-1.exp
+++ b/check/threshold-1/threshold-1.exp
@@ -15,6 +15,8 @@
 
 ./examples/docs/exported_values/code_constructs/module/module_lib.mli:6: M.unused
 
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:2: unused
 
@@ -132,6 +134,8 @@
 ./examples/docs/exported_values/hello_world/hello_world_with_intf.mli:3: goodbye
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:2: hello
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:3: goodbye
+
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:4: push_n_times
 
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_lib.mli:1: mark_used
@@ -338,6 +342,9 @@ Nothing else to report in this section
 
 .> UNUSED METHODS:
 =================
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
 
@@ -398,6 +405,10 @@ Nothing else to report in this section
 
 .>->  ALMOST UNUSED METHODS: Called 1 time(s):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#peek
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#pop
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#push
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#externally_used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#internally_used
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#externally_used

--- a/check/threshold-1/threshold-1.exp
+++ b/check/threshold-1/threshold-1.exp
@@ -145,6 +145,8 @@
 
 ./examples/docs/methods/code_constructs/object_type/object_type_bin.ml:4: push_n_times
 
+./examples/docs/methods/limitations/alias/alias_lib.mli:8: alias
+
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_lib.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_no_intf.mli:1: mark_used
@@ -361,6 +363,8 @@ Nothing else to report in this section
 
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
 
+./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#unused
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
 
@@ -435,6 +439,9 @@ Nothing else to report in this section
 
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#used
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#used_by_child
+
+./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#used
+./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#used_by_alias
 
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#externally_used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#internally_used

--- a/check/threshold-1/threshold-1.exp
+++ b/check/threshold-1/threshold-1.exp
@@ -154,6 +154,8 @@
 
 ./examples/docs/methods/code_constructs/object_type/object_type_bin.ml:4: push_n_times
 
+./examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_bin.ml:2: push_n_times
+
 ./examples/docs/methods/limitations/alias/alias_lib.mli:8: alias
 
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
@@ -377,6 +379,8 @@ Nothing else to report in this section
 
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
 
+./examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_lib.mli:2: stack#reset
+
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#unused
 
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding#m
@@ -462,6 +466,10 @@ Nothing else to report in this section
 
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#used
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#used_by_child
+
+./examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_lib.mli:2: stack#peek
+./examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_lib.mli:2: stack#pop
+./examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_lib.mli:2: stack#push
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#used
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#used_by_alias

--- a/check/threshold-1/threshold-1.ref
+++ b/check/threshold-1/threshold-1.ref
@@ -144,6 +144,8 @@
 
 ./examples/docs/methods/code_constructs/class_type/class_type_bin.ml:4: push_n_times
 
+./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:4: push_n_times
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:4: push_n_times
 
 ./examples/docs/methods/code_constructs/object_type/object_type_bin.ml:4: push_n_times
@@ -356,6 +358,9 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/class/class_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:2: unused_class#unused_method
+./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#reset
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 
@@ -424,6 +429,10 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#pop
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#push
+
+./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#peek
+./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#pop
+./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#push
 
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#pop
@@ -984,7 +993,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 843
-Success: 838
+Total: 849
+Success: 844
 Failed: 5
-Ratio: 99.4068801898%
+Ratio: 99.4110718492%

--- a/check/threshold-1/threshold-1.ref
+++ b/check/threshold-1/threshold-1.ref
@@ -140,6 +140,8 @@
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:2: hello
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:3: goodbye
 
+./examples/docs/methods/code_constructs/class/class_bin.ml:4: push_n_times
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:4: push_n_times
 
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
@@ -347,6 +349,9 @@ Nothing else to report in this section
 
 .> UNUSED METHODS:
 =================
+./examples/docs/methods/code_constructs/class/class_bin.ml:2: unused_class#unused_method
+./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#reset
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 
@@ -410,6 +415,10 @@ Nothing else to report in this section
 
 .>->  ALMOST UNUSED METHODS: Called 1 time(s):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#peek
+./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#pop
+./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#push
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#pop
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#push
@@ -966,7 +975,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 832
-Success: 827
+Total: 838
+Success: 833
 Failed: 5
-Ratio: 99.3990384615%
+Ratio: 99.4033412888%

--- a/check/threshold-1/threshold-1.ref
+++ b/check/threshold-1/threshold-1.ref
@@ -146,6 +146,8 @@
 
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:4: push_n_times
 
+./examples/docs/methods/code_constructs/object_type/object_type_bin.ml:4: push_n_times
+
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_lib.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_no_intf.mli:1: mark_used
@@ -982,7 +984,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 842
-Success: 837
+Total: 843
+Success: 838
 Failed: 5
-Ratio: 99.406175772%
+Ratio: 99.4068801898%

--- a/check/threshold-1/threshold-1.ref
+++ b/check/threshold-1/threshold-1.ref
@@ -357,6 +357,8 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
 
@@ -424,6 +426,9 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#pop
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#push
+
+./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#used
+./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#used_by_child
 
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#externally_used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#internally_used
@@ -977,7 +982,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 839
-Success: 834
+Total: 842
+Success: 837
 Failed: 5
-Ratio: 99.4040524434%
+Ratio: 99.406175772%

--- a/check/threshold-1/threshold-1.ref
+++ b/check/threshold-1/threshold-1.ref
@@ -144,6 +144,8 @@
 
 ./examples/docs/methods/code_constructs/class_type/class_type_bin.ml:4: push_n_times
 
+./examples/docs/methods/code_constructs/coercion/coercion_lib.mli:2: obj
+
 ./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:4: push_n_times
 
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:4: push_n_times
@@ -360,6 +362,8 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/class/class_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/coercion/coercion_lib.mli:2: obj#unused
+
 ./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#reset
 
@@ -433,6 +437,8 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#pop
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#push
+
+./examples/docs/methods/code_constructs/coercion/coercion_lib.mli:2: obj#used_by_requirement
 
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#pop
@@ -999,7 +1005,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 854
-Success: 847
+Total: 857
+Success: 850
 Failed: 7
-Ratio: 99.1803278689%
+Ratio: 99.1831971995%

--- a/check/threshold-1/threshold-1.ref
+++ b/check/threshold-1/threshold-1.ref
@@ -142,6 +142,8 @@
 
 ./examples/docs/methods/code_constructs/class/class_bin.ml:4: push_n_times
 
+./examples/docs/methods/code_constructs/class_type/class_type_bin.ml:4: push_n_times
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:4: push_n_times
 
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
@@ -975,7 +977,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 838
-Success: 833
+Total: 839
+Success: 834
 Failed: 5
-Ratio: 99.4033412888%
+Ratio: 99.4040524434%

--- a/check/threshold-1/threshold-1.ref
+++ b/check/threshold-1/threshold-1.ref
@@ -20,6 +20,8 @@
 ./examples/docs/exported_values/limitations/incl_same_name/oo.mli:40: new_method: Should not be detected
 ./examples/docs/exported_values/limitations/incl_same_name/oo.mli:41: public_method_label: Should not be detected
 ./examples/docs/exported_values/limitations/sigincl/sigincl_lib.mli:10: I.x: Should not be detected
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:2: unused
 
@@ -137,6 +139,8 @@
 ./examples/docs/exported_values/hello_world/hello_world_with_intf.mli:3: goodbye
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:2: hello
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:3: goodbye
+
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:4: push_n_times
 
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_lib.mli:1: mark_used
@@ -343,6 +347,9 @@ Nothing else to report in this section
 
 .> UNUSED METHODS:
 =================
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
 
@@ -403,6 +410,10 @@ Nothing else to report in this section
 
 .>->  ALMOST UNUSED METHODS: Called 1 time(s):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#peek
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#pop
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#push
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#externally_used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#internally_used
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#externally_used
@@ -955,7 +966,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 825
-Success: 820
+Total: 832
+Success: 827
 Failed: 5
-Ratio: 99.3939393939%
+Ratio: 99.3990384615%

--- a/check/threshold-1/threshold-1.ref
+++ b/check/threshold-1/threshold-1.ref
@@ -150,6 +150,8 @@
 
 ./examples/docs/methods/code_constructs/object_type/object_type_bin.ml:4: push_n_times
 
+./examples/docs/methods/limitations/alias/alias_lib.mli:8: alias
+
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_lib.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_no_intf.mli:1: mark_used
@@ -366,6 +368,8 @@ Nothing else to report in this section
 
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
 
+./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#unused
+./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#used_by_alias: Should not be detected
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
 
@@ -441,6 +445,8 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#used
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#used_by_child
 
+./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#used
+./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#used_by_alias: Not detected
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#externally_used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#internally_used
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#externally_used
@@ -993,7 +999,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 849
-Success: 844
-Failed: 5
-Ratio: 99.4110718492%
+Total: 854
+Success: 847
+Failed: 7
+Ratio: 99.1803278689%

--- a/check/threshold-1/threshold-1.ref
+++ b/check/threshold-1/threshold-1.ref
@@ -20,7 +20,12 @@
 ./examples/docs/exported_values/limitations/incl_same_name/oo.mli:40: new_method: Should not be detected
 ./examples/docs/exported_values/limitations/incl_same_name/oo.mli:41: public_method_label: Should not be detected
 ./examples/docs/exported_values/limitations/sigincl/sigincl_lib.mli:10: I.x: Should not be detected
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_bin.ml:2: unused_factory
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj
+
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:8: random_factory
 
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:2: unused
@@ -147,6 +152,8 @@
 ./examples/docs/methods/code_constructs/coercion/coercion_lib.mli:2: obj
 
 ./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:4: push_n_times
+
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_bin.ml:4: push_n_times
 
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:4: push_n_times
 
@@ -367,6 +374,9 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_bin.ml:2: unused_factory#unused_method
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_lib.mli:2: get_stack#reset
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 
@@ -374,6 +384,9 @@ Nothing else to report in this section
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#unused
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#used_by_alias: Should not be detected
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding#m: Not detected
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:8: random_factory#m
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
 
@@ -443,6 +456,10 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#pop
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#push
+
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_lib.mli:2: get_stack#peek
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_lib.mli:2: get_stack#pop
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_lib.mli:2: get_stack#push
 
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#pop
@@ -958,6 +975,9 @@ Nothing else to report in this section
 
 ./examples/docs/exported_values/limitations/sigincl/sigincl_lib.ml:9: unit pattern x
 
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:3: let x = ... in x (=> useless binding)
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:12: let x = ... in x (=> useless binding)
+
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: let () = ... in ... (=> use sequence)
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: unit pattern unit_binding
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:84: val f: ... -> (... -> ?_:_ -> ...) -> ...
@@ -1005,7 +1025,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 857
-Success: 850
-Failed: 7
-Ratio: 99.1831971995%
+Total: 870
+Success: 862
+Failed: 8
+Ratio: 99.0804597701%

--- a/check/threshold-1/threshold-1.ref
+++ b/check/threshold-1/threshold-1.ref
@@ -159,6 +159,8 @@
 
 ./examples/docs/methods/code_constructs/object_type/object_type_bin.ml:4: push_n_times
 
+./examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_bin.ml:2: push_n_times
+
 ./examples/docs/methods/limitations/alias/alias_lib.mli:8: alias
 
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
@@ -382,6 +384,8 @@ Nothing else to report in this section
 
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
 
+./examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_lib.mli:2: stack#reset
+
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#unused
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#used_by_alias: Should not be detected
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding#m: Not detected
@@ -467,6 +471,10 @@ Nothing else to report in this section
 
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#used
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#used_by_child
+
+./examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_lib.mli:2: stack#peek
+./examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_lib.mli:2: stack#pop
+./examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_lib.mli:2: stack#push
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#used
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#used_by_alias: Not detected
@@ -1025,7 +1033,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 870
-Success: 862
+Total: 875
+Success: 867
 Failed: 8
-Ratio: 99.0804597701%
+Ratio: 99.0857142857%

--- a/check/threshold-3-0.5/threshold-3-0.5.exp
+++ b/check/threshold-3-0.5/threshold-3-0.5.exp
@@ -135,6 +135,8 @@
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:2: hello
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:3: goodbye
 
+./examples/docs/methods/code_constructs/class/class_bin.ml:4: push_n_times
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:4: push_n_times
 
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
@@ -472,6 +474,9 @@ Nothing else to report in this section
 
 .> UNUSED METHODS:
 =================
+./examples/docs/methods/code_constructs/class/class_bin.ml:2: unused_class#unused_method
+./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#reset
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 
@@ -535,6 +540,10 @@ Nothing else to report in this section
 
 .>->  ALMOST UNUSED METHODS: Called 1 time(s):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#peek
+./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#pop
+./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#push
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#pop
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#push

--- a/check/threshold-3-0.5/threshold-3-0.5.exp
+++ b/check/threshold-3-0.5/threshold-3-0.5.exp
@@ -154,6 +154,8 @@
 
 ./examples/docs/methods/code_constructs/object_type/object_type_bin.ml:4: push_n_times
 
+./examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_bin.ml:2: push_n_times
+
 ./examples/docs/methods/limitations/alias/alias_lib.mli:8: alias
 
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
@@ -515,6 +517,8 @@ Nothing else to report in this section
 
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
 
+./examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_lib.mli:2: stack#reset
+
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#unused
 
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding#m
@@ -600,6 +604,10 @@ Nothing else to report in this section
 
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#used
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#used_by_child
+
+./examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_lib.mli:2: stack#peek
+./examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_lib.mli:2: stack#pop
+./examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_lib.mli:2: stack#push
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#used
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#used_by_alias

--- a/check/threshold-3-0.5/threshold-3-0.5.exp
+++ b/check/threshold-3-0.5/threshold-3-0.5.exp
@@ -484,6 +484,8 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
 
@@ -551,6 +553,9 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#pop
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#push
+
+./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#used
+./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#used_by_child
 
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#externally_used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#internally_used

--- a/check/threshold-3-0.5/threshold-3-0.5.exp
+++ b/check/threshold-3-0.5/threshold-3-0.5.exp
@@ -139,6 +139,8 @@
 
 ./examples/docs/methods/code_constructs/class_type/class_type_bin.ml:4: push_n_times
 
+./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:4: push_n_times
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:4: push_n_times
 
 ./examples/docs/methods/code_constructs/object_type/object_type_bin.ml:4: push_n_times
@@ -485,6 +487,9 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/class/class_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:2: unused_class#unused_method
+./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#reset
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 
@@ -553,6 +558,10 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#pop
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#push
+
+./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#peek
+./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#pop
+./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#push
 
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#pop

--- a/check/threshold-3-0.5/threshold-3-0.5.exp
+++ b/check/threshold-3-0.5/threshold-3-0.5.exp
@@ -141,6 +141,8 @@
 
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:4: push_n_times
 
+./examples/docs/methods/code_constructs/object_type/object_type_bin.ml:4: push_n_times
+
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_lib.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_no_intf.mli:1: mark_used
@@ -456,6 +458,8 @@
 ./examples/docs/methods/code_constructs/class_type/class_type_lib.mli:10: int_stack
 
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack
+
+./examples/docs/methods/code_constructs/object_type/object_type_lib.mli:9: int_stack
 
 ./examples/using_dune/unwrapped_lib/values/values_no_intf.ml:19: aliased_fun
 

--- a/check/threshold-3-0.5/threshold-3-0.5.exp
+++ b/check/threshold-3-0.5/threshold-3-0.5.exp
@@ -15,6 +15,8 @@
 
 ./examples/docs/exported_values/code_constructs/module/module_lib.mli:6: M.unused
 
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:2: unused
 
@@ -132,6 +134,8 @@
 ./examples/docs/exported_values/hello_world/hello_world_with_intf.mli:3: goodbye
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:2: hello
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:3: goodbye
+
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:4: push_n_times
 
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_lib.mli:1: mark_used
@@ -445,6 +449,8 @@
 
 .>->  ALMOST UNUSED EXPORTED VALUES: Called 3 time(s):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack
+
 ./examples/using_dune/unwrapped_lib/values/values_no_intf.ml:19: aliased_fun
 
 ./examples/using_dune/wrapped_lib/values/values_no_intf.ml:19: aliased_fun
@@ -466,6 +472,9 @@ Nothing else to report in this section
 
 .> UNUSED METHODS:
 =================
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
 
@@ -526,6 +535,10 @@ Nothing else to report in this section
 
 .>->  ALMOST UNUSED METHODS: Called 1 time(s):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#peek
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#pop
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#push
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#externally_used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#internally_used
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#externally_used

--- a/check/threshold-3-0.5/threshold-3-0.5.exp
+++ b/check/threshold-3-0.5/threshold-3-0.5.exp
@@ -145,6 +145,8 @@
 
 ./examples/docs/methods/code_constructs/object_type/object_type_bin.ml:4: push_n_times
 
+./examples/docs/methods/limitations/alias/alias_lib.mli:8: alias
+
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_lib.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_no_intf.mli:1: mark_used
@@ -352,6 +354,8 @@
 ./examples/docs/exported_values/hello_world/hello_world_with_intf.mli:4: world
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:4: world
 
+./examples/docs/methods/limitations/alias/alias_lib.mli:2: original
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:2: used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:31: exported_f
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:38: internally_used_f
@@ -495,6 +499,8 @@ Nothing else to report in this section
 
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
 
+./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#unused
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
 
@@ -569,6 +575,9 @@ Nothing else to report in this section
 
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#used
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#used_by_child
+
+./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#used
+./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#used_by_alias
 
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#externally_used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#internally_used

--- a/check/threshold-3-0.5/threshold-3-0.5.exp
+++ b/check/threshold-3-0.5/threshold-3-0.5.exp
@@ -137,6 +137,8 @@
 
 ./examples/docs/methods/code_constructs/class/class_bin.ml:4: push_n_times
 
+./examples/docs/methods/code_constructs/class_type/class_type_bin.ml:4: push_n_times
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:4: push_n_times
 
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
@@ -451,6 +453,8 @@
 
 .>->  ALMOST UNUSED EXPORTED VALUES: Called 3 time(s):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+./examples/docs/methods/code_constructs/class_type/class_type_lib.mli:10: int_stack
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack
 
 ./examples/using_dune/unwrapped_lib/values/values_no_intf.ml:19: aliased_fun

--- a/check/threshold-3-0.5/threshold-3-0.5.exp
+++ b/check/threshold-3-0.5/threshold-3-0.5.exp
@@ -15,7 +15,12 @@
 
 ./examples/docs/exported_values/code_constructs/module/module_lib.mli:6: M.unused
 
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_bin.ml:2: unused_factory
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj
+
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:8: random_factory
 
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:2: unused
@@ -142,6 +147,8 @@
 ./examples/docs/methods/code_constructs/coercion/coercion_lib.mli:2: obj
 
 ./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:4: push_n_times
+
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_bin.ml:4: push_n_times
 
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:4: push_n_times
 
@@ -465,6 +472,8 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ./examples/docs/methods/code_constructs/class_type/class_type_lib.mli:10: int_stack
 
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_lib.mli:2: get_stack
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack
 
 ./examples/docs/methods/code_constructs/object_type/object_type_lib.mli:9: int_stack
@@ -498,12 +507,18 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_bin.ml:2: unused_factory#unused_method
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_lib.mli:2: get_stack#reset
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#unused
+
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding#m
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:8: random_factory#m
 
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
@@ -574,6 +589,10 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#pop
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#push
+
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_lib.mli:2: get_stack#peek
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_lib.mli:2: get_stack#pop
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_lib.mli:2: get_stack#push
 
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#pop
@@ -1350,6 +1369,9 @@ Nothing else to report in this section
 ./examples/docs/exported_values/code_constructs/module/module_lib.ml:7: unit pattern unused_unexported
 
 ./examples/docs/exported_values/limitations/sigincl/sigincl_lib.ml:9: unit pattern x
+
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:3: let x = ... in x (=> useless binding)
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:12: let x = ... in x (=> useless binding)
 
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: let () = ... in ... (=> use sequence)
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: unit pattern unit_binding

--- a/check/threshold-3-0.5/threshold-3-0.5.exp
+++ b/check/threshold-3-0.5/threshold-3-0.5.exp
@@ -139,6 +139,8 @@
 
 ./examples/docs/methods/code_constructs/class_type/class_type_bin.ml:4: push_n_times
 
+./examples/docs/methods/code_constructs/coercion/coercion_lib.mli:2: obj
+
 ./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:4: push_n_times
 
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:4: push_n_times
@@ -491,6 +493,8 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/class/class_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/coercion/coercion_lib.mli:2: obj#unused
+
 ./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#reset
 
@@ -564,6 +568,8 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#pop
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#push
+
+./examples/docs/methods/code_constructs/coercion/coercion_lib.mli:2: obj#used_by_requirement
 
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#pop

--- a/check/threshold-3-0.5/threshold-3-0.5.ref
+++ b/check/threshold-3-0.5/threshold-3-0.5.ref
@@ -144,6 +144,8 @@
 
 ./examples/docs/methods/code_constructs/class_type/class_type_bin.ml:4: push_n_times
 
+./examples/docs/methods/code_constructs/coercion/coercion_lib.mli:2: obj
+
 ./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:4: push_n_times
 
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:4: push_n_times
@@ -496,6 +498,8 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/class/class_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/coercion/coercion_lib.mli:2: obj#unused
+
 ./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#reset
 
@@ -569,6 +573,8 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#pop
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#push
+
+./examples/docs/methods/code_constructs/coercion/coercion_lib.mli:2: obj#used_by_requirement
 
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#pop
@@ -1396,7 +1402,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 1170
-Success: 1163
+Total: 1173
+Success: 1166
 Failed: 7
-Ratio: 99.4017094017%
+Ratio: 99.4032395567%

--- a/check/threshold-3-0.5/threshold-3-0.5.ref
+++ b/check/threshold-3-0.5/threshold-3-0.5.ref
@@ -140,6 +140,8 @@
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:2: hello
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:3: goodbye
 
+./examples/docs/methods/code_constructs/class/class_bin.ml:4: push_n_times
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:4: push_n_times
 
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
@@ -477,6 +479,9 @@ Nothing else to report in this section
 
 .> UNUSED METHODS:
 =================
+./examples/docs/methods/code_constructs/class/class_bin.ml:2: unused_class#unused_method
+./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#reset
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 
@@ -540,6 +545,10 @@ Nothing else to report in this section
 
 .>->  ALMOST UNUSED METHODS: Called 1 time(s):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#peek
+./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#pop
+./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#push
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#pop
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#push
@@ -1357,7 +1366,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 1145
-Success: 1140
+Total: 1151
+Success: 1146
 Failed: 5
-Ratio: 99.5633187773%
+Ratio: 99.5655951347%

--- a/check/threshold-3-0.5/threshold-3-0.5.ref
+++ b/check/threshold-3-0.5/threshold-3-0.5.ref
@@ -20,6 +20,8 @@
 ./examples/docs/exported_values/limitations/incl_same_name/oo.mli:40: new_method: Should not be detected
 ./examples/docs/exported_values/limitations/incl_same_name/oo.mli:41: public_method_label: Should not be detected
 ./examples/docs/exported_values/limitations/sigincl/sigincl_lib.mli:10: I.x: Should not be detected
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:2: unused
 
@@ -137,6 +139,8 @@
 ./examples/docs/exported_values/hello_world/hello_world_with_intf.mli:3: goodbye
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:2: hello
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:3: goodbye
+
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:4: push_n_times
 
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_lib.mli:1: mark_used
@@ -450,6 +454,8 @@
 
 .>->  ALMOST UNUSED EXPORTED VALUES: Called 3 time(s):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack
+
 ./examples/using_dune/unwrapped_lib/values/values_no_intf.ml:19: aliased_fun
 
 ./examples/using_dune/wrapped_lib/values/values_no_intf.ml:19: aliased_fun
@@ -471,6 +477,9 @@ Nothing else to report in this section
 
 .> UNUSED METHODS:
 =================
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
 
@@ -531,6 +540,10 @@ Nothing else to report in this section
 
 .>->  ALMOST UNUSED METHODS: Called 1 time(s):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#peek
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#pop
+./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#push
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#externally_used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#internally_used
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#externally_used
@@ -1344,7 +1357,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 1137
-Success: 1132
+Total: 1145
+Success: 1140
 Failed: 5
-Ratio: 99.5602462621%
+Ratio: 99.5633187773%

--- a/check/threshold-3-0.5/threshold-3-0.5.ref
+++ b/check/threshold-3-0.5/threshold-3-0.5.ref
@@ -146,6 +146,8 @@
 
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:4: push_n_times
 
+./examples/docs/methods/code_constructs/object_type/object_type_bin.ml:4: push_n_times
+
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_lib.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_no_intf.mli:1: mark_used
@@ -461,6 +463,8 @@
 ./examples/docs/methods/code_constructs/class_type/class_type_lib.mli:10: int_stack
 
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack
+
+./examples/docs/methods/code_constructs/object_type/object_type_lib.mli:9: int_stack
 
 ./examples/using_dune/unwrapped_lib/values/values_no_intf.ml:19: aliased_fun
 
@@ -1375,7 +1379,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 1156
-Success: 1151
+Total: 1158
+Success: 1153
 Failed: 5
-Ratio: 99.5674740484%
+Ratio: 99.5682210708%

--- a/check/threshold-3-0.5/threshold-3-0.5.ref
+++ b/check/threshold-3-0.5/threshold-3-0.5.ref
@@ -142,6 +142,8 @@
 
 ./examples/docs/methods/code_constructs/class/class_bin.ml:4: push_n_times
 
+./examples/docs/methods/code_constructs/class_type/class_type_bin.ml:4: push_n_times
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:4: push_n_times
 
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
@@ -456,6 +458,8 @@
 
 .>->  ALMOST UNUSED EXPORTED VALUES: Called 3 time(s):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+./examples/docs/methods/code_constructs/class_type/class_type_lib.mli:10: int_stack
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack
 
 ./examples/using_dune/unwrapped_lib/values/values_no_intf.ml:19: aliased_fun
@@ -1366,7 +1370,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 1151
-Success: 1146
+Total: 1153
+Success: 1148
 Failed: 5
-Ratio: 99.5655951347%
+Ratio: 99.5663486557%

--- a/check/threshold-3-0.5/threshold-3-0.5.ref
+++ b/check/threshold-3-0.5/threshold-3-0.5.ref
@@ -144,6 +144,8 @@
 
 ./examples/docs/methods/code_constructs/class_type/class_type_bin.ml:4: push_n_times
 
+./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:4: push_n_times
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:4: push_n_times
 
 ./examples/docs/methods/code_constructs/object_type/object_type_bin.ml:4: push_n_times
@@ -490,6 +492,9 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/class/class_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:2: unused_class#unused_method
+./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#reset
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 
@@ -558,6 +563,10 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#pop
 ./examples/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#push
+
+./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#peek
+./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#pop
+./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#push
 
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#pop
@@ -1379,7 +1388,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 1158
-Success: 1153
+Total: 1164
+Success: 1159
 Failed: 5
-Ratio: 99.5682210708%
+Ratio: 99.5704467354%

--- a/check/threshold-3-0.5/threshold-3-0.5.ref
+++ b/check/threshold-3-0.5/threshold-3-0.5.ref
@@ -159,6 +159,8 @@
 
 ./examples/docs/methods/code_constructs/object_type/object_type_bin.ml:4: push_n_times
 
+./examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_bin.ml:2: push_n_times
+
 ./examples/docs/methods/limitations/alias/alias_lib.mli:8: alias
 
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
@@ -520,6 +522,8 @@ Nothing else to report in this section
 
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
 
+./examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_lib.mli:2: stack#reset
+
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#unused
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#used_by_alias: Should not be detected
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding#m: Not detected
@@ -605,6 +609,10 @@ Nothing else to report in this section
 
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#used
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#used_by_child
+
+./examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_lib.mli:2: stack#peek
+./examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_lib.mli:2: stack#pop
+./examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_lib.mli:2: stack#push
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#used
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#used_by_alias: Not detected
@@ -1424,7 +1432,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 1187
-Success: 1179
+Total: 1192
+Success: 1184
 Failed: 8
-Ratio: 99.3260320135%
+Ratio: 99.3288590604%

--- a/check/threshold-3-0.5/threshold-3-0.5.ref
+++ b/check/threshold-3-0.5/threshold-3-0.5.ref
@@ -150,6 +150,8 @@
 
 ./examples/docs/methods/code_constructs/object_type/object_type_bin.ml:4: push_n_times
 
+./examples/docs/methods/limitations/alias/alias_lib.mli:8: alias
+
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_lib.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_no_intf.mli:1: mark_used
@@ -357,6 +359,8 @@
 ./examples/docs/exported_values/hello_world/hello_world_with_intf.mli:4: world
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:4: world
 
+./examples/docs/methods/limitations/alias/alias_lib.mli:2: original
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:2: used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:31: exported_f
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:38: internally_used_f
@@ -500,6 +504,8 @@ Nothing else to report in this section
 
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
 
+./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#unused
+./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#used_by_alias: Should not be detected
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
 
@@ -575,6 +581,8 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#used
 ./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#used_by_child
 
+./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#used
+./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#used_by_alias: Not detected
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#externally_used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#internally_used
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#externally_used
@@ -1388,7 +1396,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 1164
-Success: 1159
-Failed: 5
-Ratio: 99.5704467354%
+Total: 1170
+Success: 1163
+Failed: 7
+Ratio: 99.4017094017%

--- a/check/threshold-3-0.5/threshold-3-0.5.ref
+++ b/check/threshold-3-0.5/threshold-3-0.5.ref
@@ -20,7 +20,12 @@
 ./examples/docs/exported_values/limitations/incl_same_name/oo.mli:40: new_method: Should not be detected
 ./examples/docs/exported_values/limitations/incl_same_name/oo.mli:41: public_method_label: Should not be detected
 ./examples/docs/exported_values/limitations/sigincl/sigincl_lib.mli:10: I.x: Should not be detected
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_bin.ml:2: unused_factory
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj
+
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:8: random_factory
 
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:2: unused
@@ -147,6 +152,8 @@
 ./examples/docs/methods/code_constructs/coercion/coercion_lib.mli:2: obj
 
 ./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:4: push_n_times
+
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_bin.ml:4: push_n_times
 
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:4: push_n_times
 
@@ -470,6 +477,8 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ./examples/docs/methods/code_constructs/class_type/class_type_lib.mli:10: int_stack
 
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_lib.mli:2: get_stack
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack
 
 ./examples/docs/methods/code_constructs/object_type/object_type_lib.mli:9: int_stack
@@ -503,6 +512,9 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/constructor/constructor_bin.ml:2: unused_class#unused_method
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_bin.ml:2: unused_factory#unused_method
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_lib.mli:2: get_stack#reset
+
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 
@@ -510,6 +522,9 @@ Nothing else to report in this section
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#unused
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original#used_by_alias: Should not be detected
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding#m: Not detected
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:8: random_factory#m
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
 
@@ -579,6 +594,10 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#pop
 ./examples/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#push
+
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_lib.mli:2: get_stack#peek
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_lib.mli:2: get_stack#pop
+./examples/docs/methods/code_constructs/factory_fun/factory_fun_lib.mli:2: get_stack#push
 
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#pop
@@ -1355,6 +1374,9 @@ Nothing else to report in this section
 
 ./examples/docs/exported_values/limitations/sigincl/sigincl_lib.ml:9: unit pattern x
 
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:3: let x = ... in x (=> useless binding)
+./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:12: let x = ... in x (=> useless binding)
+
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: let () = ... in ... (=> use sequence)
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: unit pattern unit_binding
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:84: val f: ... -> (... -> ?_:_ -> ...) -> ...
@@ -1402,7 +1424,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 1173
-Success: 1166
-Failed: 7
-Ratio: 99.4032395567%
+Total: 1187
+Success: 1179
+Failed: 8
+Ratio: 99.3260320135%

--- a/check/threshold-3-0.5/threshold-3-0.5.ref
+++ b/check/threshold-3-0.5/threshold-3-0.5.ref
@@ -489,6 +489,8 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
 
+./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:12: immediate#unused
 
@@ -556,6 +558,9 @@ Nothing else to report in this section
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#peek
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#pop
 ./examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#push
+
+./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#used
+./examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#used_by_child
 
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#externally_used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:6: immediate#internally_used
@@ -1370,7 +1375,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 1153
-Success: 1148
+Total: 1156
+Success: 1151
 Failed: 5
-Ratio: 99.5663486557%
+Ratio: 99.5674740484%

--- a/docs/USER_DOC.md
+++ b/docs/USER_DOC.md
@@ -54,6 +54,7 @@ This documentation is split accross different topics:
 
 - [Usage](USAGE.md) describes the usage of the `dead_code_analyzer` and its options.
 - [Exported Values](exported_values/EXPORTED_VALUES.md) describes the semantics and usage of the "unused exported values" report section, and provides examples.
+- [Methods](methods/METHODS.md) describes the semantics and usage of the "unused methods" report section, and provides examples.
 
 
 ## Footnotes

--- a/docs/methods/METHODS.md
+++ b/docs/methods/METHODS.md
@@ -142,6 +142,7 @@ from the `.mli` if there is one and the `.ml`.
 - The [code constructs](./code_constructs) directory contains a collection of
   examples dedicated to specific code constructs :
     - [Class](./code_constructs/CLASS.md)
+    - [Polymorphic class](./code_constructs/CLASS.md)
     - [Constructor](./code_constructs/CONSTRUCTOR.md)
     - [Class type](./code_constructs/CLASS_TYPE.md)
     - [Inheritance](./code_constructs/INHERITANCE.md)

--- a/docs/methods/METHODS.md
+++ b/docs/methods/METHODS.md
@@ -8,6 +8,7 @@
 + [Examples](#examples)
 + [Limitations](#limitations)
     +[Class type](#class-type)
+    +[Object type](#object-type)
 
 # Methods
 
@@ -142,6 +143,7 @@ from the `.mli` if there is one and the `.ml`.
     - [Class](./code_constructs/CLASS.md)
     - [Class type](./code_constructs/CLASS_TYPE.md)
     - [Inheritance](./code_constructs/INHERITANCE.md)
+    - [Object type](./code_constructs/OBJECT_TYPE.md)
 
 # Limitations
 
@@ -150,3 +152,9 @@ from the `.mli` if there is one and the `.ml`.
 As explained in the [Class type](./code_constructs/CLASS_TYPE.md) example, the
 analyzer is currently restricted to not reporting methods declared in class
 type definitions.
+
+## Object type
+
+As explained in the [Object type](./code_constructs/OBJECT_TYPE.md) example, the
+analyzer is currently restricted to not reporting methods declared in object
+types.

--- a/docs/methods/METHODS.md
+++ b/docs/methods/METHODS.md
@@ -139,12 +139,12 @@ from the `.mli` if there is one and the `.ml`.
 
 - The [code constructs](./code_constructs) directory contains a collection of
   examples dedicated to specific code constructs :
-    - [Immediate object](./code_constructs/IMMEDIATE_OBJECT.md)
     - [Class](./code_constructs/CLASS.md)
+    - [Constructor](./code_constructs/CONSTRUCTOR.md)
     - [Class type](./code_constructs/CLASS_TYPE.md)
     - [Inheritance](./code_constructs/INHERITANCE.md)
+    - [Immediate object](./code_constructs/IMMEDIATE_OBJECT.md)
     - [Object type](./code_constructs/OBJECT_TYPE.md)
-    - [Constructor](./code_constructs/CONSTRUCTOR.md)
 
 # Limitations
 

--- a/docs/methods/METHODS.md
+++ b/docs/methods/METHODS.md
@@ -9,6 +9,7 @@
 + [Limitations](#limitations)
     +[Class type](#class-type)
     +[Object type](#object-type)
+    +[Alias](#alias)
 
 # Methods
 
@@ -159,3 +160,97 @@ type definitions.
 As explained in the [Object type](./code_constructs/OBJECT_TYPE.md) example, the
 analyzer is currently restricted to not reporting methods declared in object
 types.
+
+## Alias
+
+Related issue :
+[issue #66](https://github.com/LexiFi/dead_code_analyzer/issues/66).
+
+In the presence of multiple bindings to the same object, the analyzer corrctly
+avoids tracking their methods individually. However, it fails at unifying them
+and only keeps track of the methods used through the original binding, where the
+methods are defined. This leads to **false positives**.
+
+### Example
+
+The reference files for this example are in the
+[alias](../../examples/docs/methods/limitations/alias) directory.
+
+The reference takes place in `/tmp/docs/methods/limitations`, which
+is a copy of the [limitations](../../../examples/docs/methods/limitations)
+directory. Reported locations may differ depending on the location of the source
+files.
+
+The compilation command is :
+```
+make -C alias build
+```
+
+The analysis command is :
+```
+make -C alias analyze
+```
+
+The compile + analyze command is :
+```
+make -C alias
+```
+
+Code:
+```OCaml
+(* alias_lib.mli *)
+val original :
+  < used : unit
+  ; used_by_alias : unit
+  ; unused : unit
+  >
+
+val alias :
+  < used : unit
+  ; used_by_alias : unit
+  ; unused : unit
+  >
+```
+```OCaml
+(* alias_lib.ml *)
+let original =
+  object
+    method used = ()
+    method used_by_alias = ()
+    method unused = ()
+  end
+
+let alias = original
+```
+```OCaml
+(* alias_bin.ml *)
+open Alias_lib
+
+let () =
+  original#used;
+  alias#used_by_alias
+```
+
+Compile and analyze:
+```
+$ make -C alias
+make: Entering directory '/tmp/docs/methods/limitations/alias'
+ocamlopt -bin-annot alias_lib.mli alias_lib.ml alias_bin.ml
+dead_code_analyzer --nothing -M all .
+Scanning files...
+ [DONE]
+
+.> UNUSED METHODS:
+=================
+/tmp/docs/methods/limitations/alias/alias_lib.mli:2: original#unused
+/tmp/docs/methods/limitations/alias/alias_lib.mli:2: original#used_by_alias
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/methods/limitations/alias'
+```
+
+The analyzer reports `original#used_by_alias` although it is used by
+`alias#used_by_alias`.

--- a/docs/methods/METHODS.md
+++ b/docs/methods/METHODS.md
@@ -1,0 +1,132 @@
+# Table of contents
+
++ [Methods](#methods)
+    + [Definitions](#definitions)
+    + [Compiler warnings](#compiler-warnings)
+        + [Warning 26: unused-ancestor](#warning-36-unused-ancestor)
+    + [Usage](#usage)
+
+# Methods
+
+## Definitions
+
+A **method** is declared using the `method` keyword in the definition of a class
+or an immediate object, or as a field of an object type.
+
+An **instance variable** is declared using the `val` keyword in the definition
+of a class or an immediate object. It does not appear in object types.
+
+A **public** method is not a private method.
+A **private** method is one declared with the `private` keyword.
+
+An **exported** method is one that exists in its compilation unit's signature
+
+A **use** is either :
+- An explicit reference.
+  E.g.
+  ```OCaml
+  let o = object method answer = 42 end
+  let () = print_int o#answer
+  ```
+  The method `answer` is explicitly referenced in `o#answer`.
+- A requirement for that method to exist.
+  E.g.
+  ```OCaml
+  let print_answer param = print_int param#answer
+  let o = object method answer = 42 end
+  let () = print_answer o
+  ```
+  The type of `print_answer` is `< answer : int; .. > -> unit`, meaning that its
+  arguments are required to at least provide a method named `answer`. Therefore,
+  `o#answer` is used by requirement in `print_answer o`. If `o` did not provide
+  method `answer`, then the compilation would fail with an error like :
+  ```
+  File "requirement.ml", line 4, characters 22-23:
+  4 | let () = print_answer o
+                            ^
+  Error: This expression has type <  > but an expression was expected of type
+           < answer : int; .. >
+         The first object type has no method answer
+  ```
+
+## Compiler warnings
+
+The analyzer reports unused exported public methods. The compiler does not
+report unused methods (private or public, exported or not, from a class, an
+immediate, or an object type), not instance vraiables. Thus, the 2 tools do not
+complement each other.
+
+> [!WARNING]
+> Only a portion of the unused object-related code can be reported using the
+> compiler and the analyzer : unused exported public methods. Unused private or
+> unexported methods, as well as unused instance variables will remain
+> undetected.
+
+> [!IMPORTANT]
+> Exported values of object or class types belong to the
+> [Exported values](../exported_values/EXPORTED_VALUES.md) section.
+
+Although the compiler does not report unused methods or instance variables, it
+still has a few object-related warnings, of which one is related to unused code
+constructs : warning 36.
+
+### Warning 36: unused-ancestor
+
+This warning is disabled by default.
+I can be enabled by passing the `-w +36` to the compiler.
+
+Description:
+```
+36 [unused-ancestor] Unused ancestor variable. (since 4.00)
+```
+
+Example:
+```OCaml
+(* warning36.ml *)
+class c1 = object end
+class c2 = object
+   inherit c1 as super
+end
+```
+```
+$ ocamlopt -w +36 warning36.ml
+File "warning36.ml", line 4, characters 3-22:
+4 |    inherit c1 as super
+       ^^^^^^^^^^^^^^^^^^^
+Warning 36 [unused-ancestor]: unused ancestor variable super.
+```
+
+## Usage
+
+Unused exported public methods are reported by default.
+Their reports can be deactivated by using the `--nothing` or `-M nothing`
+command line arguments.
+They can be reactivated by using the `--all` or `-M all` command line arguments.
+For more details about the command line arguments see [the more general Usage
+documentation](../USAGE.md).
+
+The report section looks like:
+
+```
+.> UNUSED METHODS:
+=================
+filepath:line: source#method
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+```
+The report line format is `filepath:line: value` with `filepath` the absolute
+path to the file (`.mli` if available, `.ml` otherwise) where `source` is
+declared, `line` the line index in `filepath` at which `source` is declared,
+`source` the path of the object/class within its compilation unit (e.g. `M.c`)
+which declares `method`, and `method` the unused method.
+There can be any number of such lines.
+
+The expected resolution for an unused exported public method is to remove it
+from the `.mli` if there is one and the `.ml`.
+
+> [!IMPORTANT]
+> Removing unused methods or values from the codebase may trigger the detection
+> of new unused methods, or remove some for values of object types.
+> Consequently, it is expected that a user might need to compile and analyze
+> their code multiple times when cleaning up their codebase.

--- a/docs/methods/METHODS.md
+++ b/docs/methods/METHODS.md
@@ -144,6 +144,7 @@ from the `.mli` if there is one and the `.ml`.
     - [Class type](./code_constructs/CLASS_TYPE.md)
     - [Inheritance](./code_constructs/INHERITANCE.md)
     - [Object type](./code_constructs/OBJECT_TYPE.md)
+    - [Constructor](./code_constructs/CONSTRUCTOR.md)
 
 # Limitations
 

--- a/docs/methods/METHODS.md
+++ b/docs/methods/METHODS.md
@@ -138,8 +138,8 @@ from the `.mli` if there is one and the `.ml`.
   examples dedicated to specific code constructs :
     - [Immediate object](./code_constructs/IMMEDIATE_OBJECT.md)
     - [Class](./code_constructs/CLASS.md)
+    - [Class type](./code_constructs/CLASS_TYPE.md)
 
 [TODO]: # (
-    - [Class type](./code_constructs/CLASS_TYPE.md)
     - [Inheritance](./code_constructs/INHERITANCE.md)
     )

--- a/docs/methods/METHODS.md
+++ b/docs/methods/METHODS.md
@@ -5,6 +5,7 @@
     + [Compiler warnings](#compiler-warnings)
         + [Warning 26: unused-ancestor](#warning-36-unused-ancestor)
     + [Usage](#usage)
++ [Examples](#examples)
 
 # Methods
 
@@ -130,3 +131,15 @@ from the `.mli` if there is one and the `.ml`.
 > of new unused methods, or remove some for values of object types.
 > Consequently, it is expected that a user might need to compile and analyze
 > their code multiple times when cleaning up their codebase.
+
+# Examples
+
+- The [code constructs](./code_constructs) directory contains a collection of
+  examples dedicated to specific code constructs :
+    - [Immediate object](./code_constructs/IMMEDIATE_OBJECT.md)
+
+[TODO]: # (
+    - [Class](./code_constructs/CLASS.md)
+    - [Class type](./code_constructs/CLASS_TYPE.md)
+    - [Inheritance](./code_constructs/INHERITANCE.md)
+    )

--- a/docs/methods/METHODS.md
+++ b/docs/methods/METHODS.md
@@ -6,6 +6,8 @@
         + [Warning 26: unused-ancestor](#warning-36-unused-ancestor)
     + [Usage](#usage)
 + [Examples](#examples)
++ [Limitations](#limitations)
+    +[Class type](#class-type)
 
 # Methods
 
@@ -140,3 +142,11 @@ from the `.mli` if there is one and the `.ml`.
     - [Class](./code_constructs/CLASS.md)
     - [Class type](./code_constructs/CLASS_TYPE.md)
     - [Inheritance](./code_constructs/INHERITANCE.md)
+
+# Limitations
+
+## Class type
+
+As explained in the [Class type](./code_constructs/CLASS_TYPE.md) example, the
+analyzer is currently restricted to not reporting methods declared in class
+type definitions.

--- a/docs/methods/METHODS.md
+++ b/docs/methods/METHODS.md
@@ -146,6 +146,7 @@ from the `.mli` if there is one and the `.ml`.
     - [Inheritance](./code_constructs/INHERITANCE.md)
     - [Immediate object](./code_constructs/IMMEDIATE_OBJECT.md)
     - [Object type](./code_constructs/OBJECT_TYPE.md)
+    - [Coercion](./code_constructs/COERCION.md)
 
 # Limitations
 

--- a/docs/methods/METHODS.md
+++ b/docs/methods/METHODS.md
@@ -10,6 +10,7 @@
     +[Class type](#class-type)
     +[Object type](#object-type)
     +[Alias](#alias)
+    +[Factory function](#factory-function)
 
 # Methods
 
@@ -145,6 +146,7 @@ from the `.mli` if there is one and the `.ml`.
     - [Class type](./code_constructs/CLASS_TYPE.md)
     - [Inheritance](./code_constructs/INHERITANCE.md)
     - [Immediate object](./code_constructs/IMMEDIATE_OBJECT.md)
+    - [Factory function](./code_constructs/FACTORY_FUN.md)
     - [Object type](./code_constructs/OBJECT_TYPE.md)
     - [Coercion](./code_constructs/COERCION.md)
 
@@ -255,3 +257,86 @@ make: Leaving directory '/tmp/docs/methods/limitations/alias'
 
 The analyzer reports `original#used_by_alias` although it is used by
 `alias#used_by_alias`.
+
+## Factory function
+
+Related issue :
+[issue #67](https://github.com/LexiFi/dead_code_analyzer/issues/67).
+
+Factory functions' methods analysis is currently very limited to situations like
+the one in the [Factory function](./code_constructs/FACTORY_FUN.md) example :
+functions without intermediate binding to the returned object in at least one
+branch. I.e. if in all the branches, the result object is bound to a name, then
+the analyzer fails to track its methods. This leads to **false negatives**.
+
+### Example
+
+The reference files for this example are in the
+[factory\_fun\_indir](../../examples/docs/methods/limitations/factory_fun_indir) directory.
+
+The reference takes place in `/tmp/docs/methods/limitations`, which
+is a copy of the [limitations](../../../examples/docs/methods/limitations)
+directory. Reported locations may differ depending on the location of the source
+files.
+
+The compilation command is :
+```
+make -C factory_fun_indir build
+```
+
+The analysis command is :
+```
+make -C factory_fun_indir analyze
+```
+
+The compile + analyze command is :
+```
+make -C factory_fun_indir
+```
+
+Code:
+```OCaml
+(* factoy_fun_indir.ml *)
+let factory_with_intermediate_binding () =
+  let res =
+    object method m = () end
+  in
+  res
+
+let random_factory () =
+  if Random.bool () then
+    object method m = () end
+  else
+    let res = object method m = () end in
+    res
+```
+
+Compile and analyze:
+```
+$ make -C factory_fun_indir
+make: Entering directory '/tmp/docs/methods/limitations/factory_fun_indir'
+ocamlopt -bin-annot factory_fun_indir.ml
+dead_code_analyzer --nothing -M all .
+Scanning files...
+ [DONE]
+
+.> UNUSED METHODS:
+=================
+/tmp/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:8: random_factory#m
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/methods/limitations/factory_fun_indir'
+```
+
+The analyzer correctly reports `random_factory#m` because its last expression in
+the `if` branch is the object's definition. It does not report
+`factory_with_intermediate_binding#m` because the returned object is bound
+inside the function.
+
+> [!NOTE]
+> The analyzer does not distinguish which object is actually returned when there
+> are alternatives like in `random_factory`. Only uses outside of the function
+> are accounted for. E.g. using `res#m` in the `else` branch does not count.

--- a/docs/methods/METHODS.md
+++ b/docs/methods/METHODS.md
@@ -137,9 +137,9 @@ from the `.mli` if there is one and the `.ml`.
 - The [code constructs](./code_constructs) directory contains a collection of
   examples dedicated to specific code constructs :
     - [Immediate object](./code_constructs/IMMEDIATE_OBJECT.md)
+    - [Class](./code_constructs/CLASS.md)
 
 [TODO]: # (
-    - [Class](./code_constructs/CLASS.md)
     - [Class type](./code_constructs/CLASS_TYPE.md)
     - [Inheritance](./code_constructs/INHERITANCE.md)
     )

--- a/docs/methods/METHODS.md
+++ b/docs/methods/METHODS.md
@@ -139,7 +139,4 @@ from the `.mli` if there is one and the `.ml`.
     - [Immediate object](./code_constructs/IMMEDIATE_OBJECT.md)
     - [Class](./code_constructs/CLASS.md)
     - [Class type](./code_constructs/CLASS_TYPE.md)
-
-[TODO]: # (
     - [Inheritance](./code_constructs/INHERITANCE.md)
-    )

--- a/docs/methods/METHODS.md
+++ b/docs/methods/METHODS.md
@@ -60,7 +60,8 @@ A **use** is either :
 The analyzer reports unused exported public methods. The compiler does not
 report unused methods (private or public, exported or not, from a class, an
 immediate, or an object type), not instance vraiables. Thus, the 2 tools do not
-complement each other.
+complement each other, and unused unexported methods or unused exported private
+methods remain undetected.
 
 > [!WARNING]
 > Only a portion of the unused object-related code can be reported using the
@@ -79,7 +80,7 @@ constructs : warning 36.
 ### Warning 36: unused-ancestor
 
 This warning is disabled by default.
-I can be enabled by passing the `-w +36` to the compiler.
+It can be enabled by passing `-w +36` to the compiler.
 
 Description:
 ```
@@ -132,8 +133,10 @@ The expected resolution for an unused exported public method is to remove it
 from the `.mli` if there is one and the `.ml`.
 
 > [!IMPORTANT]
-> Removing unused methods or values from the codebase may trigger the detection
-> of new unused methods, or remove some for values of object types.
+> Removing unused methods from the codebase may trigger the detection of new
+> unused methods and new unused values. Removing unused values may trigger the
+> detection of new unused methods or remove some in the case of values of
+> object types.
 > Consequently, it is expected that a user might need to compile and analyze
 > their code multiple times when cleaning up their codebase.
 
@@ -142,7 +145,7 @@ from the `.mli` if there is one and the `.ml`.
 - The [code constructs](./code_constructs) directory contains a collection of
   examples dedicated to specific code constructs :
     - [Class](./code_constructs/CLASS.md)
-    - [Polymorphic class](./code_constructs/CLASS.md)
+    - [Polymorphic class](./code_constructs/POLYMORPHIC_CLASS.md)
     - [Constructor](./code_constructs/CONSTRUCTOR.md)
     - [Class type](./code_constructs/CLASS_TYPE.md)
     - [Inheritance](./code_constructs/INHERITANCE.md)

--- a/docs/methods/code_constructs/CLASS.md
+++ b/docs/methods/code_constructs/CLASS.md
@@ -1,0 +1,218 @@
+The reference files for this example are in the
+[class](../../../examples/docs/methods/code_constructs/class) directory.
+
+The reference takes place in `/tmp/docs/methods/code_constructs`, which
+is a copy of the [code\_constructs](../../../examples/docs/methods/code_constructs)
+directory. Reported locations may differ depending on the location of the source
+files.
+
+The compilation command is :
+```
+make -C class build
+```
+
+The analysis command is :
+```
+make -C class analyze
+```
+
+The compile + analyze command is :
+```
+make -C class
+```
+
+## First run
+
+Code:
+```OCaml
+(* class_lib.mli *)
+class int_stack :
+  object
+    method push : int -> unit
+    method pop : unit
+    method peek : int option
+    method reset : unit
+  end
+```
+```OCaml
+(* class_lib.ml *)
+class int_stack =
+  object
+    val mutable l : int list = []
+    method push x = l <- x::l
+    method pop =
+      match l with
+      | [] -> ()
+      | _::tl -> l <- tl
+    method peek =
+      match l with
+      | [] -> None
+      | hd::_ -> Some hd
+    method reset = l <- []
+  end
+```
+```OCaml
+(* class_bin.ml *)
+class unused_class = object method unused_method = () end
+
+let push_n_times n stack =
+  for i = 1 to n do
+    stack#push i;
+  done
+
+let () =
+  let int_stack = new Class_lib.int_stack in
+  let n = 42 in
+  push_n_times n int_stack;
+  while int_stack#peek <> None do
+    int_stack#pop;
+  done
+```
+
+Before looking at the analysis results, let's look at the code.
+
+The `Class_lib` declares and exports 1 class : `int_stack`. An instance of this
+class is used in `Class_bin`.
+`Class_bin` declares and exports 1 class : `unused_class`, which is unused.
+All of the methods are public, so they are tracked by the analyzer.
+
+2 methods are explicitly referenced : `int_stack#peek`, and `int_stack#pop`.
+1 method is used by requirement : `int_stack#push`, required by the call
+`push_n_times n int_stack`.
+
+This leaves only 2 unused methods : `int_stack#reset` and
+`unused_obj#unused_method`.
+
+Compile and analyze:
+```
+$ make -C class
+make: Entering directory '/tmp/docs/methods/code_constructs/class'
+ocamlopt -bin-annot class_lib.mli class_lib.ml class_bin.ml
+dead_code_analyzer --nothing -M all .
+Scanning files...
+ [DONE]
+
+.> UNUSED METHODS:
+=================
+/tmp/docs/methods/code_constructs/class/class_bin.ml:2: unused_class#unused_method
+/tmp/docs/methods/code_constructs/class/class_lib.mli:2: int_stack#reset
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/methods/code_constructs/class'
+```
+
+As expected, 2 methods are reported unused : `unused_class#unused_method`, and
+`int_stack#reset`. These can be removed from the class definitions at the
+reported locations.
+
+> [!IMPORTANT]
+> The reported locations are those of the classes to which the methods belong.
+
+> [!NOTE]
+> The objects manipulated in this example are instances of classes. Thus, their
+> methods are those of their classes.
+> If the analyzer reported unused methods for each instance, a user would need
+> to explicit the signature of each object rather than simply rely on the
+> (possibly inferred) defined class type. This is a non-trivial resolution
+> of unused methods, effectively losing the benefits of using class types.
+> Consequently, the analyzer does not report unused methods of instances but
+> only of the classes they belong to.
+
+In addition to these unused methods, there is the unused exported class
+`unused_class` which is currently not reportable by the analyzer.
+
+## Removing the unused methods
+
+> [!TIP]
+> Do not forget to remove `int_stack#reset` from both the `.mli` **and** the `.ml`.
+> Otherwise, the compiler will reject the code with a message like :
+> ```
+> File "class_lib.ml", line 1:
+> Error: The implementation class_lib.ml
+>        does not match the interface class_lib.mli:
+>        Class declarations do not match:
+>          class int_stack :
+>            object
+>              val mutable l : int list
+>              method peek : int option
+>              method pop : unit
+>              method push : int -> unit
+>              method reset : unit
+>            end
+>        does not match
+>          class int_stack :
+>            object
+>              method peek : int option
+>              method pop : unit
+>              method push : int -> unit
+>            end
+>        The public method reset cannot be hidden
+> ```
+
+Code:
+```OCaml
+(* class_lib.mli *)
+class int_stack :
+  object
+    method push : int -> unit
+    method pop : unit
+    method peek : int option
+  end
+```
+```OCaml
+(* class_lib.ml *)
+class int_stack =
+  object
+    val mutable l : int list = []
+    method push x = l <- x::l
+    method pop =
+      match l with
+      | [] -> ()
+      | _::tl -> l <- tl
+    method peek =
+      match l with
+      | [] -> None
+      | hd::_ -> Some hd
+  end
+```
+```OCaml
+(* class_bin.ml *)
+class unused_class = object end
+
+let push_n_times n stack =
+  for i = 1 to n do
+    stack#push i;
+  done
+
+let () =
+  let int_stack = new Class_lib.int_stack in
+  let n = 42 in
+  push_n_times n int_stack;
+  while int_stack#peek <> None do
+    int_stack#pop;
+  done
+```
+
+Compile and analyze:
+```
+$ make -C class
+make: Entering directory '/tmp/docs/methods/code_constructs/class'
+ocamlopt -bin-annot class_lib.mli class_lib.ml class_bin.ml
+dead_code_analyzer --nothing -M all .
+Scanning files...
+ [DONE]
+
+.> UNUSED METHODS:
+=================
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/methods/code_constructs/class'
+```
+
+There is no more unused method. Our work here is done.

--- a/docs/methods/code_constructs/CLASS_TYPE.md
+++ b/docs/methods/code_constructs/CLASS_TYPE.md
@@ -1,0 +1,113 @@
+The reference files for this example are in the
+[class\_type](../../../examples/docs/methods/code_constructs/class_type) directory.
+
+The reference takes place in `/tmp/docs/methods/code_constructs`, which
+is a copy of the [code\_constructs](../../../examples/docs/methods/code_constructs)
+directory. Reported locations may differ depending on the location of the source
+files.
+
+The compilation command is :
+```
+make -C class_type build
+```
+
+The analysis command is :
+```
+make -C class_type analyze
+```
+
+The compile + analyze command is :
+```
+make -C class_type
+```
+
+> [!IMPORTANT]
+> **LIMITATION**
+>
+> Methods declared in class types definition (different from class signatures)
+> are currently ignored by the analyzer.
+
+## First run
+
+Code:
+```OCaml
+(* class_type_lib.mli *)
+class type int_stack =
+  object
+    method push : int -> unit
+    method pop : unit
+    method peek : int option
+    method reset : unit
+  end
+
+val int_stack : int_stack
+```
+```OCaml
+(* class_type_lib.ml *)
+class type int_stack =
+  object
+    method push : int -> unit
+    method pop : unit
+    method peek : int option
+    method reset : unit
+  end
+
+let int_stack =
+  object
+    val mutable l : int list = []
+    method push x = l <- x::l
+    method pop =
+      match l with
+      | [] -> ()
+      | _::tl -> l <- tl
+    method peek =
+      match l with
+      | [] -> None
+      | hd::_ -> Some hd
+    method reset = l <- []
+  end
+```
+```OCaml
+(* class_type_bin.ml *)
+class type unused_class_type = object method unused_method : unit end
+
+let push_n_times n stack =
+  for i = 1 to n do
+    stack#push i;
+  done
+
+let () =
+  let open Class_type_lib in
+  let n = 42 in
+  push_n_times n int_stack;
+  while int_stack#peek <> None do
+    int_stack#pop;
+  done
+```
+
+By looking at the code, we could make the same observation as in the
+[Class](./CLASS.md) example.
+
+However, because of the current limitation on class types, nothing is expected
+to reported.
+
+Code and analyze:
+```
+$ make -C class_type
+make: Entering directory '/tmp/docs/methods/code_construct/class_type'
+ocamlopt -bin-annot class_type_lib.mli class_type_lib.ml class_type_bin.ml
+dead_code_analyzer --nothing -M all .
+Scanning files...
+ [DONE]
+
+.> UNUSED METHODS:
+=================
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/methods/code_construct/class_type'
+```
+
+Nothing is reported. Our work here is done.

--- a/docs/methods/code_constructs/COERCION.md
+++ b/docs/methods/code_constructs/COERCION.md
@@ -50,11 +50,11 @@ let () =
 
 Before looking at the analysis results, let's look at the code.
 
-There is 1 object : `Coercion_lib.obj`, which defined 2 zmthods :
+There is 1 object : `Coercion_lib.obj`, which defined 2 methods :
 `used_by_requirement`, and `unused`. Neither of them is explicitly referenced,
 and the object is only manipulated through a coercion. The coercion produces an
 alias to `obj` named `_coerce`, which only exposes the method
-`used_by_requirement`. Because the method is required to exists in `obj` for the
+`used_by_requirement`. Because the method is required to exists in `obj` by the
 coercion, then the analyzer effectively considers it as used by requirement.
 
 Compile and analyze:
@@ -77,6 +77,6 @@ Nothing else to report in this section
 make: Leaving directory '/tmp/docs/methods/code_constructs/coercion'
 ```
 
-As expected, the anlyzer reports `obj#unsed` as unused and not
+As expected, the analyzer reports `obj#unsed` as unused and not
 `obj#used_by_requirement`. The unused method can be removed from the `.mli` and
 the `.ml`. Our work here is done.

--- a/docs/methods/code_constructs/COERCION.md
+++ b/docs/methods/code_constructs/COERCION.md
@@ -1,0 +1,82 @@
+The reference files for this example are in the
+[coercion](../../../examples/docs/methods/code_constructs/coercion) directory.
+
+The reference takes place in `/tmp/docs/methods/code_constructs`, which
+is a copy of the [code\_constructs](../../../examples/docs/methods/code_constructs)
+directory. Reported locations may differ depending on the location of the source
+files.
+
+The compilation command is :
+```
+make -C coercion build
+```
+
+The analysis command is :
+```
+make -C coercion analyze
+```
+
+The compile + analyze command is :
+```
+make -C coercion
+```
+
+## First run
+
+Code:
+```OCaml
+(* coercion_lib.mli *)
+val obj :
+  < used_by_requirement : unit
+  ; unused : unit
+  >
+```
+```OCaml
+(* coercion_lib.ml *)
+let obj =
+  object
+    method used_by_requirement = ()
+    method unused = ()
+  end
+```
+```OCaml
+(* coercion_bin.ml *)
+open Coercion_lib
+
+let () =
+  let _coerce = (obj :> < used_by_requirement : unit >) in
+  ()
+```
+
+Before looking at the analysis results, let's look at the code.
+
+There is 1 object : `Coercion_lib.obj`, which defined 2 zmthods :
+`used_by_requirement`, and `unused`. Neither of them is explicitly referenced,
+and the object is only manipulated through a coercion. The coercion produces an
+alias to `obj` named `_coerce`, which only exposes the method
+`used_by_requirement`. Because the method is required to exists in `obj` for the
+coercion, then the analyzer effectively considers it as used by requirement.
+
+Compile and analyze:
+```
+$ make -C coercion
+make: Entering directory '/tmp/docs/methods/code_constructs/coercion'
+ocamlopt -bin-annot coercion_lib.mli coercion_lib.ml coercion_bin.ml
+dead_code_analyzer --nothing -M all .
+Scanning files...
+ [DONE]
+
+.> UNUSED METHODS:
+=================
+/tmp/docs/methods/code_constructs/coercion/coercion_lib.mli:2: obj#unused
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/methods/code_constructs/coercion'
+```
+
+As expected, the anlyzer reports `obj#unsed` as unused and not
+`obj#used_by_requirement`. The unused method can be removed from the `.mli` and
+the `.ml`. Our work here is done.

--- a/docs/methods/code_constructs/CONSTRUCTOR.md
+++ b/docs/methods/code_constructs/CONSTRUCTOR.md
@@ -1,0 +1,101 @@
+The reference files for this example are in the
+[constructor](../../../examples/docs/methods/code_constructs/constructor) directory.
+
+The reference takes place in `/tmp/docs/methods/code_constructs`, which
+is a copy of the [code\_constructs](../../../examples/docs/methods/code_constructs)
+directory. Reported locations may differ depending on the location of the source
+files.
+
+The compilation command is :
+```
+make -C constructor build
+```
+
+The analysis command is :
+```
+make -C constructor analyze
+```
+
+The compile + analyze command is :
+```
+make -C constructor
+```
+
+## First run
+
+Code:
+```OCaml
+(* constructor_lib.mli *)
+class int_stack :
+  int list ->
+  object
+    method push : int -> unit
+    method pop : unit
+    method peek : int option
+    method reset : unit
+  end
+```
+```OCaml
+(* constructor_lib.ml *)
+class int_stack init =
+  object
+    val mutable l : int list = init
+    method push x = l <- x::l
+    method pop =
+      match l with
+      | [] -> ()
+      | _::tl -> l <- tl
+    method peek =
+      match l with
+      | [] -> None
+      | hd::_ -> Some hd
+    method reset = l <- []
+  end
+```
+```OCaml
+(* constructor_bin.ml *)
+class unused_class _ = object method unused_method = () end
+
+let push_n_times n stack =
+  for i = 1 to n do
+    stack#push i;
+  done
+
+let () =
+  let int_stack = new Constructor_lib.int_stack [] in
+  let n = 42 in
+  push_n_times n int_stack;
+  while int_stack#peek <> None do
+    int_stack#pop;
+  done
+```
+
+The code is very similar to the one of the [Class](./CLASS.md) example, with a
+small twist : the classes have initialisers. Because the analyzer does not track
+each instance' methods uses individually but unified whith the defining class,
+the presence of initialisers should not make a difference and the expected
+results are the same as in the [Class](./CLASS.md) example.
+
+Compile and analyze:
+```
+$ make -C constructor
+make: Entering directory '/tmp/docs/methods/code_constructs/constructor'
+ocamlopt -bin-annot constructor_lib.mli constructor_lib.ml constructor_bin.ml
+dead_code_analyzer --nothing -M all .
+Scanning files...
+ [DONE]
+
+.> UNUSED METHODS:
+=================
+/tmp/docs/methods/code_constructs/constructor/constructor_bin.ml:2: unused_class#unused_method
+/tmp/docs/methods/code_constructs/constructor/constructor_lib.mli:2: int_stack#reset
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/methods/code_constructs/constructor'
+```
+
+The results are the same as expected. The resolution is already detailed in the
+[Class](./CLASS.md) example. Our work here is done.

--- a/docs/methods/code_constructs/FACTORY_FUN.md
+++ b/docs/methods/code_constructs/FACTORY_FUN.md
@@ -87,7 +87,7 @@ let () =
 Before looking at the analysis results, let's look at the code.
 
 The `Factory_fun_lib` declares and exports 1 factory function `get_stack` which
-takes `unit` as parameter and returns a fresh object. The return object has
+takes `unit` as parameter and returns a fresh object. The returned object has
 4 methods, manipulating the unexported value `stack`.
 1 of these methods is used by requirement : `push`.
 2 of these methods are explicitly referenced : `peek`, and `pop`.

--- a/docs/methods/code_constructs/FACTORY_FUN.md
+++ b/docs/methods/code_constructs/FACTORY_FUN.md
@@ -1,0 +1,128 @@
+The reference files for this example are in the
+[factory_fun](../../../examples/docs/methods/code_constructs/factory_fun) directory.
+
+The reference takes place in `/tmp/docs/methods/code_constructs`, which
+is a copy of the [code\_constructs](../../../examples/docs/methods/code_constructs)
+directory. Reported locations may differ depending on the location of the source
+files.
+
+The compilation command is :
+```
+make -C factory_fun build
+```
+
+The analysis command is :
+```
+make -C factory_fun analyze
+```
+
+The compile + analyze command is :
+```
+make -C factory_fun
+```
+
+> [!IMPORTANT]
+> **LIMITATION**
+>
+> Only factory functions that return the object without intermediate binding
+> in at least one branch are understood by the analyzer. This may lead to
+> **false negatives**.
+> See [Factory function | Limitations](../METHODS.md#factory-function).
+>
+> Storing the result of a factory function in a new binding breaks the analysis.
+> Although 2 calls to the same factory function may produce different objects,
+> they are considered to be the same by the analyzer. Hence, storing the result
+> in a new binding is similar to an alias, which may lead to **false positives**.
+> See [Alias | Limitations](../METHODS.md#alias)
+
+## First run
+
+Code:
+```OCaml
+(* factoy_fun_lib.mli *)
+val get_stack :
+  unit ->
+  < push : int -> unit
+  ; pop : unit
+  ; peek : int option
+  ; reset : unit
+  >
+```
+```OCaml
+(* factoy_fun_lib.ml *)
+let stack = ref []
+
+let get_stack () =
+  object
+    method push x = stack := x::!stack
+    method pop =
+      match !stack with
+      | [] -> ()
+      | _::tl -> stack := tl
+    method peek =
+      match !stack with
+      | [] -> None
+      | hd::_ -> Some hd
+    method reset = stack := []
+  end
+```
+```OCaml
+(* factoy_fun_bin.ml *)
+let unused_factory () = object method unused_method = () end
+
+let push_n_times n stack =
+  for i = 1 to n do
+    stack#push i;
+  done
+
+let () =
+  let open Factory_fun_lib in
+  let n = 42 in
+  push_n_times n (get_stack ());
+  while (get_stack ())#peek <> None do
+    (get_stack ())#pop;
+  done
+```
+
+Before looking at the analysis results, let's look at the code.
+
+The `Factory_fun_lib` declares and exports 1 factory function `get_stack` which
+takes `unit` as parameter and returns a fresh object. The return object has
+4 methods, manipulating the unexported value `stack`.
+1 of these methods is used by requirement : `push`.
+2 of these methods are explicitly referenced : `peek`, and `pop`.
+This leaves `reset` as unused.
+
+The `Factory_fun_bin` declares and exports 1 factory function `unused_factory`
+which takes `unit` as parameter and returns a fresh object with one method
+`unused_method`. This function is unused, leaving its method unused too.
+
+Compile and analyze:
+```
+$ make -C factory_fun
+make: Entering directory '/tmp/docs/methods/code_constructs/factory_fun'
+ocamlopt -bin-annot factory_fun_lib.mli factory_fun_lib.ml factory_fun_bin.ml
+dead_code_analyzer --nothing -M all .
+Scanning files...
+ [DONE]
+
+.> UNUSED METHODS:
+=================
+/tmp/docs/methods/code_constructs/factory_fun/factory_fun_bin.ml:2: unused_factory#unused_method
+/tmp/docs/methods/code_constructs/factory_fun/factory_fun_lib.mli:2: get_stack#reset
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/methods/code_constructs/factory_fun'
+```
+
+As expected, the analyzer reports `unused_factory#unused_method` and
+`get_stack#reset` as unused. Following the report line format
+`filepath:line: source#method`, here the sources are the functions themselves.
+Indeed, the returned objects are defined as the immediate results of the
+functions, making the functions behave similarly to class constructors.
+
+The reported methods can be removed from the `.mli` and `.ml`.
+Our work here is done.

--- a/docs/methods/code_constructs/IMMEDIATE_OBJECT.md
+++ b/docs/methods/code_constructs/IMMEDIATE_OBJECT.md
@@ -1,0 +1,232 @@
+The reference files for this example are in the
+[immediate\_object](../../../examples/docs/methods/code_constructs/immediate_object) directory.
+
+The reference takes place in `/tmp/docs/methods/code_constructs`, which
+is a copy of the [code\_constructs](../../../examples/docs/methods/code_constructs)
+directory. Reported locations may differ depending on the location of the source
+files.
+
+The compilation command is :
+```
+make -C immediate_object build
+```
+
+The analysis command is :
+```
+make -C immediate_object analyze
+```
+
+The compile + analyze command is :
+```
+make -C immediate_object
+```
+
+## First run
+
+Code:
+```OCaml
+(* immediate_object_lib.mli *)
+val int_stack :
+  < push : int -> unit
+  ; pop : unit
+  ; peek : int option
+  ; reset : unit
+  >
+```
+```OCaml
+(* immediate_object_lib.ml *)
+let int_stack =
+  object
+    val mutable l = []
+    method push x = l <- x::l
+    method pop =
+      match l with
+      | [] -> ()
+      | _::tl -> l <- tl
+    method peek =
+      match l with
+      | [] -> None
+      | hd::_ -> Some hd
+    method reset = l <- []
+  end
+```
+```OCaml
+(* immediate_object_bin.ml *)
+let unused_obj = object method unused_method = () end
+
+let push_n_times n stack =
+  for i = 1 to n do
+    stack#push i;
+  done
+
+let () =
+  let open Immediate_object_lib in
+  let n = 42 in
+  push_n_times n int_stack;
+  while int_stack#peek <> None do
+    int_stack#pop;
+  done
+```
+
+Before looking at the analysis results, let's look at the code.
+
+The `Imm_obj_lib` declares and exports 1 object : `int_stack`, which is used by
+`Imm_obj_bin`. `Imm_obj_bin` declares and exports 1 object : `unused_obj`, which
+is unused. All of the methods are public, so they are tracked by the analyzer.
+
+2 methods are explicitly referenced : `int_stack#peek`, and `int_stack#pop`.
+1 method is used by requirement : `int_stack#push`, required by the call
+`push_n_times n int_stack`.
+
+This leaves only 2 unused methods : `int_stack#reset` and
+`unused_obj#unused_method`.
+
+Compile and analyze:
+```
+$ make -C immediate_object
+make: Entering directory '/tmp/docs/methods/code_constructs/immediate_object'
+ocamlopt -bin-annot immediate_object_lib.mli immediate_object_lib.ml immediate_object_bin.ml
+dead_code_analyzer --nothing -M all .
+Scanning files...
+ [DONE]
+
+.> UNUSED METHODS:
+=================
+/tmp/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj#unused_method
+/tmp/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli:2: int_stack#reset
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/methods/code_constructs/immediate_object'
+```
+
+As expected, 2 methods are reported unused : `unused_obj#unused_method`, and
+`int_stack#reset`. These can be removed from the object definitions at the
+reported locations.
+
+> [!IMPORTANT]
+> The reported locations are those of the objects to which the methods belong.
+
+In addition to these unused methods, there is the unused exported value
+`unused_obj` which is not reported because we disabled the analysis of unused
+values when passing `--nothing` to the analyzer. Let's update the Makefile and
+pass `-E all` to the analyzer to enable that analysis.
+
+```
+SRC:=immediate_object_lib.mli immediate_object_lib.ml immediate_object_bin.ml
+
+all: build analyze
+
+build:
+	ocamlopt -bin-annot ${SRC}
+
+analyze:
+	dead_code_analyzer --nothing -E all -M all .
+
+clean:
+	rm -f *.cm* *.o a.out
+```
+
+## Removing the unused methods
+
+> [!TIP]
+> Do not forget to remove `int_stack#reset` from both the `.mli` **and** the `.ml`.
+> Otherwise, the compiler will reject the code with a message like :
+> ```
+> File "immediate_object_lib.ml", line 1:
+> Error: The implementation immediate_object_lib.ml
+>        does not match the interface immediate_object_lib.mli:
+>        Values do not match:
+>          val int_stack :
+>            < peek : '_weak1 option; pop : unit; push : '_weak1 -> unit;
+>              reset : unit >
+>        is not included in
+>          val int_stack :
+>            < peek : int option; pop : unit; push : int -> unit >
+>        The type
+>          < peek : '_weak1 option; pop : unit; push : '_weak1 -> unit;
+>            reset : unit >
+>        is not compatible with the type
+>          < peek : int option; pop : unit; push : int -> unit >
+>        The second object type has no method reset
+>        File "immediate_object_lib.mli", lines 2-6, characters 0-3:
+>          Expected declaration
+>        File "immediate_object_lib.ml", line 2, characters 4-13:
+>          Actual declaration
+> ```
+
+Code:
+```OCaml
+(* immediate_object_lib.mli *)
+val int_stack :
+  < push : int -> unit
+  ; pop : unit
+  ; peek : int option
+  >
+```
+```OCaml
+(* immediate_object_lib.ml *)
+let int_stack =
+  object
+    val mutable l = []
+    method push x = l <- x::l
+    method pop =
+      match l with
+      | [] -> ()
+      | _::tl -> l <- tl
+    method peek =
+      match l with
+      | [] -> None
+      | hd::_ -> Some hd
+  end
+```
+```OCaml
+(* immediate_object_bin.ml *)
+let unused_obj = object end
+
+let push_n_times n stack =
+  for i = 1 to n do
+    stack#push i;
+  done
+
+let () =
+  let open Immediate_object_lib in
+  let n = 42 in
+  push_n_times n int_stack;
+  while int_stack#peek <> None do
+    int_stack#pop;
+  done
+```
+
+Compile and analyze:
+```
+$ make -C immediate_object
+make: Entering directory '/tmp/docs/methods/code_constructs/immediate_object'
+ocamlopt -bin-annot immediate_object_lib.mli immediate_object_lib.ml immediate_object_bin.ml
+dead_code_analyzer --nothing -E all -M all .
+Scanning files...
+ [DONE]
+
+.> UNUSED EXPORTED VALUES:
+=========================
+/tmp/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml:2: unused_obj
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+.> UNUSED METHODS:
+=================
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/methods/code_constructs/immediate_object'
+```
+
+There is no more unused method. The unused exported value can be removed as
+explained in the [Exported values](../../exported_values/EXPORTED_VALUES.md) documentation.
+Our work here is done

--- a/docs/methods/code_constructs/INHERITANCE.md
+++ b/docs/methods/code_constructs/INHERITANCE.md
@@ -67,7 +67,7 @@ The code is pretty straightforward. `Inheritance_lib` defines 2 classes :
 
 CLass inheritance is semantically equivalent to module inclusion from the
 analyzer's point of view : the `parent` class is the actual "owner" of the
-methods, and `child` only re-exposes them. This, has 2 consequences :
+methods, and `child` only re-exposes them. This has 2 consequences :
 - inherited methods in `child` are not analyzed individually;
 - using a method from `child` that is inherited from `parent` is the same as
   using the method from `parent`.

--- a/docs/methods/code_constructs/INHERITANCE.md
+++ b/docs/methods/code_constructs/INHERITANCE.md
@@ -1,0 +1,105 @@
+The reference files for this example are in the
+[inheritance](../../../examples/docs/methods/code_constructs/inheritance) directory.
+
+The reference takes place in `/tmp/docs/methods/code_constructs`, which
+is a copy of the [code\_constructs](../../../examples/docs/methods/code_constructs)
+directory. Reported locations may differ depending on the location of the source
+files.
+
+The compilation command is :
+```
+make -C inheritance build
+```
+
+The analysis command is :
+```
+make -C inheritance analyze
+```
+
+The compile + analyze command is :
+```
+make -C inheritance
+```
+
+## First run
+
+Code:
+```OCaml
+(* inheritance_lib.mli *)
+class parent :
+  object
+    method unused : unit
+    method used : unit
+    method used_by_child : unit
+  end
+
+class child :
+  object
+    inherit parent
+  end
+```
+```OCaml
+(* inheritance_lib.ml *)
+class parent =
+  object
+    method unused = ()
+    method used = ()
+    method used_by_child = ()
+  end
+
+class child =
+  object
+    inherit parent
+  end
+```
+```OCaml
+(* inheritance_bin.ml *)
+let () =
+  let p = new Inheritance_lib.parent in
+  let c = new Inheritance_lib.child in
+  p#used;
+  c#used_by_child
+```
+
+The code is pretty straightforward. `Inheritance_lib` defines 2 classes :
+- `parent`, which defines 3 methods;
+- `child`, which only inherits `parent`.
+
+CLass inheritance is semantically equivalent to module inclusion from the
+analyzer's point of view : the `parent` class is the actual "owner" of the
+methods, and `child` only re-exposes them. This, has 2 consequences :
+- inherited methods in `child` are not analyzed individually;
+- using a method from `child` that is inherited from `parent` is the same as
+  using the method from `parent`.
+
+Now if we look at the uses, 2 methods are referenced explicitly :
+- `p#used`, which is `parent#used`
+- `c#used_by_child`, which is `child#used_by_child`, which is
+  `parent#used_by_child`
+
+This leaves `parent#unused` as the only unused method.
+
+Compile and analyze:
+```
+$ make -C inheritance
+make: Entering directory '/tmp/docs/methods/code_constructs/inheritance'
+ocamlopt -bin-annot inheritance_lib.mli inheritance_lib.ml inheritance_bin.ml
+dead_code_analyzer --nothing -M all .
+Scanning files...
+ [DONE]
+
+.> UNUSED METHODS:
+=================
+/tmp/docs/methods/code_constructs/inheritance/inheritance_lib.mli:2: parent#unused
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/methods/code_constructs/inheritance'
+```
+
+As expected, the analyzer reports `parent#unused` as unused. It can be removed
+from `inheritance_lib.mli` and `inheritance_lib.ml`.
+Neither the compiler nor the analyzer will report unused methods anymore.
+Our work here is done.

--- a/docs/methods/code_constructs/OBJECT_TYPE.md
+++ b/docs/methods/code_constructs/OBJECT_TYPE.md
@@ -1,0 +1,108 @@
+The reference files for this example are in the
+[object\_type](../../../examples/docs/methods/code_constructs/object_type) directory.
+
+The reference takes place in `/tmp/docs/methods/code_constructs`, which
+is a copy of the [code\_constructs](../../../examples/docs/methods/code_constructs)
+directory. Reported locations may differ depending on the location of the source
+files.
+
+The compilation command is :
+```
+make -C object_type build
+```
+
+The analysis command is :
+```
+make -C object_type analyze
+```
+
+The compile + analyze command is :
+```
+make -C object_type
+```
+
+> [!IMPORTANT]
+> **LIMITATION**
+>
+> Methods declared in object types are currently ignored by the analyzer.
+
+## First run
+
+Code:
+```OCaml
+(* object_type_lib.mli *)
+type int_stack =
+  < push : int -> unit
+  ; pop : unit
+  ; peek : int option
+  ; reset : unit
+  >
+
+val int_stack : int_stack
+```
+```OCaml
+(* object_type_lib.ml *)
+type int_stack =
+  < push : int -> unit
+  ; pop : unit
+  ; peek : int option
+  ; reset : unit
+  >
+
+let int_stack =
+  object
+    val mutable l : int list = []
+    method push x = l <- x::l
+    method pop =
+      match l with
+      | [] -> ()
+      | _::tl -> l <- tl
+    method peek =
+      match l with
+      | [] -> None
+      | hd::_ -> Some hd
+    method reset = l <- []
+  end
+```
+```OCaml
+(* object_type_bin.ml *)
+type unused_t = < unused_method : unit >
+
+let push_n_times n stack =
+  for i = 1 to n do
+    stack#push i;
+  done
+
+let () =
+  let open Object_type_lib in
+  let n = 42 in
+  push_n_times n int_stack;
+  while int_stack#peek <> None do
+    int_stack#pop;
+  done
+```
+
+By looking at the code, we could make the same observation as in the
+[Class type](./CLASS_TYPE.md) example. The analyzer's semantics are equivalent
+so the results are the same as well.
+
+Code and analyze:
+```
+$ make -C object_type
+make: Entering directory '/tmp/docs/methods/code_construct/object_type'
+ocamlopt -bin-annot object_type_lib.mli object_type_lib.ml object_type_bin.ml
+dead_code_analyzer --nothing -M all .
+Scanning files...
+ [DONE]
+
+.> UNUSED METHODS:
+=================
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/methods/code_construct/object_type'
+```
+
+Nothing is reported. Our work here is done.

--- a/docs/methods/code_constructs/POLYMORPHIC_CLASS.md
+++ b/docs/methods/code_constructs/POLYMORPHIC_CLASS.md
@@ -70,7 +70,7 @@ let () =
 Before looking at the analysis results, let's look at the code.
 
 This example is very similar to the [Class](./CLASS.md) example, without the
-`unused_class` class. Instead of using an definitive `int_stack` class, the
+`unused_class` class. Instead of using an monomorphic `int_stack` class, the
 `Polymorphic_class_lib` defines a polymorphic `['a] stack` class.
 
 Methods `push`, `peek`, and `pop` are used, leaving `reset` as the only unused method.

--- a/docs/methods/code_constructs/POLYMORPHIC_CLASS.md
+++ b/docs/methods/code_constructs/POLYMORPHIC_CLASS.md
@@ -1,0 +1,106 @@
+The reference files for this example are in the
+[polymorphic\_class](../../../examples/docs/methods/code_constructs/polymorphic_class) directory.
+
+The reference takes place in `/tmp/docs/methods/code_constructs`, which
+is a copy of the [code\_constructs](../../../examples/docs/methods/code_constructs)
+directory. Reported locations may differ depending on the location of the source
+files.
+
+The compilation command is :
+```
+make -C polymorphic_class build
+```
+
+The analysis command is :
+```
+make -C polymorphic_class analyze
+```
+
+The compile + analyze command is :
+```
+make -C polymorphic_class
+```
+
+## First run
+
+Code:
+```OCaml
+(* polymorphic_class_lib.mli *)
+class ['a] stack :
+  object
+    method push : 'a -> unit
+    method pop : unit
+    method peek : 'a option
+    method reset : unit
+  end
+```
+```OCaml
+(* polymorphic_class_lib.ml *)
+class ['a] stack =
+  object
+    val mutable l : 'a list = []
+    method push x = l <- x::l
+    method pop =
+      match l with
+      | [] -> ()
+      | _::tl -> l <- tl
+    method peek =
+      match l with
+      | [] -> None
+      | hd::_ -> Some hd
+    method reset = l <- []
+  end
+```
+```OCaml
+(* polymorphic_class_bin.ml *)
+let push_n_times n stack =
+  for i = 1 to n do
+    stack#push i;
+  done
+
+let () =
+  let int_stack = new Polymorphic_class_lib.stack in
+  let n = 42 in
+  push_n_times n int_stack;
+  while int_stack#peek <> None do
+    int_stack#pop;
+  done
+```
+
+Before looking at the analysis results, let's look at the code.
+
+This example is very similar to the [Class](./CLASS.md) example, without the
+`unused_class` class. Instead of using an definitive `int_stack` class, the
+`Polymorphic_class_lib` defines a polymorphic `['a] stack` class.
+
+Methods `push`, `peek`, and `pop` are used, leaving `reset` as the only unused method.
+
+Compile and analyze:
+```
+$ make -C polymorphic_class/
+make: Entering directory '/tmp/docs/methods/code_constructs/polymorphic_class'
+ocamlopt -bin-annot polymorphic_class_lib.mli polymorphic_class_lib.ml polymorphic_class_bin.ml
+dead_code_analyzer --nothing -M all .
+Scanning files...
+ [DONE]
+
+.> UNUSED METHODS:
+=================
+/tmp/docs/methods/code_constructs/polymorphic_class/polymorphic_class_lib.mli:2: stack#reset
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/methods/code_constructs/polymorphic_class'
+```
+
+As expected, the analyzer reports `stack#reset` as unused.
+
+> [!NOTE]
+> The analyzer does not specify the type parameter of `stack`. This is because
+> it does not distinguish the monomorphizations of `stack` and its polymoprhic
+> definition.
+
+After removing the reported unused methods, the analyzer will not find anymore
+unused method. Our work here is done.

--- a/examples/docs/Makefile
+++ b/examples/docs/Makefile
@@ -4,8 +4,10 @@ all: build
 
 build:
 	make -C exported_values
+	make -C methods
 
 clean:
 	rm -f *~ *.cm* *.o *.obj
 	make -C exported_values clean
+	make -C methods clean
 

--- a/examples/docs/methods/Makefile
+++ b/examples/docs/methods/Makefile
@@ -1,0 +1,11 @@
+.PHONY: clean build
+
+all: build
+
+build:
+	make -C code_constructs
+
+clean:
+	rm -f *~ *.cm* *.o *.obj
+	make -C code_constructs clean
+

--- a/examples/docs/methods/Makefile
+++ b/examples/docs/methods/Makefile
@@ -4,8 +4,10 @@ all: build
 
 build:
 	make -C code_constructs
+	make -C limitations
 
 clean:
 	rm -f *~ *.cm* *.o *.obj
 	make -C code_constructs clean
+	make -C limitations clean
 

--- a/examples/docs/methods/code_constructs/Makefile
+++ b/examples/docs/methods/code_constructs/Makefile
@@ -8,6 +8,7 @@ build:
 	make -C class_type build
 	make -C inheritance build
 	make -C object_type build
+	make -C constructor build
 
 clean:
 	rm -f *~ *.cm* *.o *.obj
@@ -16,4 +17,5 @@ clean:
 	make -C class_type clean
 	make -C inheritance clean
 	make -C object_type clean
+	make -C constructor clean
 

--- a/examples/docs/methods/code_constructs/Makefile
+++ b/examples/docs/methods/code_constructs/Makefile
@@ -4,6 +4,7 @@ all: build
 
 build:
 	make -C class build
+	make -C polymorphic_class build
 	make -C constructor build
 	make -C class_type build
 	make -C inheritance build
@@ -15,6 +16,7 @@ build:
 clean:
 	rm -f *~ *.cm* *.o *.obj
 	make -C class clean
+	make -C polymorphic_class clean
 	make -C constructor clean
 	make -C class_type clean
 	make -C inheritance clean

--- a/examples/docs/methods/code_constructs/Makefile
+++ b/examples/docs/methods/code_constructs/Makefile
@@ -6,10 +6,12 @@ build:
 	make -C immediate_object build
 	make -C class build
 	make -C class_type build
+	make -C inheritance build
 
 clean:
 	rm -f *~ *.cm* *.o *.obj
 	make -C immediate_object clean
 	make -C class clean
 	make -C class_type clean
+	make -C inheritance clean
 

--- a/examples/docs/methods/code_constructs/Makefile
+++ b/examples/docs/methods/code_constructs/Makefile
@@ -3,19 +3,19 @@
 all: build
 
 build:
-	make -C immediate_object build
 	make -C class build
+	make -C constructor build
 	make -C class_type build
 	make -C inheritance build
+	make -C immediate_object build
 	make -C object_type build
-	make -C constructor build
 
 clean:
 	rm -f *~ *.cm* *.o *.obj
-	make -C immediate_object clean
 	make -C class clean
+	make -C constructor clean
 	make -C class_type clean
 	make -C inheritance clean
+	make -C immediate_object clean
 	make -C object_type clean
-	make -C constructor clean
 

--- a/examples/docs/methods/code_constructs/Makefile
+++ b/examples/docs/methods/code_constructs/Makefile
@@ -1,0 +1,11 @@
+.PHONY: clean build
+
+all: build
+
+build:
+	make -C immediate_object build
+
+clean:
+	rm -f *~ *.cm* *.o *.obj
+	make -C immediate_object clean
+

--- a/examples/docs/methods/code_constructs/Makefile
+++ b/examples/docs/methods/code_constructs/Makefile
@@ -7,6 +7,7 @@ build:
 	make -C class build
 	make -C class_type build
 	make -C inheritance build
+	make -C object_type build
 
 clean:
 	rm -f *~ *.cm* *.o *.obj
@@ -14,4 +15,5 @@ clean:
 	make -C class clean
 	make -C class_type clean
 	make -C inheritance clean
+	make -C object_type clean
 

--- a/examples/docs/methods/code_constructs/Makefile
+++ b/examples/docs/methods/code_constructs/Makefile
@@ -9,6 +9,7 @@ build:
 	make -C inheritance build
 	make -C immediate_object build
 	make -C object_type build
+	make -C coercion build
 
 clean:
 	rm -f *~ *.cm* *.o *.obj
@@ -18,4 +19,5 @@ clean:
 	make -C inheritance clean
 	make -C immediate_object clean
 	make -C object_type clean
+	make -C coercion clean
 

--- a/examples/docs/methods/code_constructs/Makefile
+++ b/examples/docs/methods/code_constructs/Makefile
@@ -4,8 +4,10 @@ all: build
 
 build:
 	make -C immediate_object build
+	make -C class build
 
 clean:
 	rm -f *~ *.cm* *.o *.obj
 	make -C immediate_object clean
+	make -C class clean
 

--- a/examples/docs/methods/code_constructs/Makefile
+++ b/examples/docs/methods/code_constructs/Makefile
@@ -8,6 +8,7 @@ build:
 	make -C class_type build
 	make -C inheritance build
 	make -C immediate_object build
+	make -C factory_fun build
 	make -C object_type build
 	make -C coercion build
 
@@ -18,6 +19,7 @@ clean:
 	make -C class_type clean
 	make -C inheritance clean
 	make -C immediate_object clean
+	make -C factory_fun clean
 	make -C object_type clean
 	make -C coercion clean
 

--- a/examples/docs/methods/code_constructs/Makefile
+++ b/examples/docs/methods/code_constructs/Makefile
@@ -5,9 +5,11 @@ all: build
 build:
 	make -C immediate_object build
 	make -C class build
+	make -C class_type build
 
 clean:
 	rm -f *~ *.cm* *.o *.obj
 	make -C immediate_object clean
 	make -C class clean
+	make -C class_type clean
 

--- a/examples/docs/methods/code_constructs/class/Makefile
+++ b/examples/docs/methods/code_constructs/class/Makefile
@@ -1,0 +1,12 @@
+SRC:=class_lib.mli class_lib.ml class_bin.ml
+
+all: build analyze
+
+build:
+	ocamlopt -bin-annot ${SRC}
+
+analyze:
+	dead_code_analyzer --nothing -M all .
+
+clean:
+	rm -f *.cm* *.o a.out

--- a/examples/docs/methods/code_constructs/class/class_bin.ml
+++ b/examples/docs/methods/code_constructs/class/class_bin.ml
@@ -1,0 +1,15 @@
+(* class_bin.ml *)
+class unused_class = object method unused_method = () end
+
+let push_n_times n stack =
+  for i = 1 to n do
+    stack#push i;
+  done
+
+let () =
+  let int_stack = new Class_lib.int_stack in
+  let n = 42 in
+  push_n_times n int_stack;
+  while int_stack#peek <> None do
+    int_stack#pop;
+  done

--- a/examples/docs/methods/code_constructs/class/class_lib.ml
+++ b/examples/docs/methods/code_constructs/class/class_lib.ml
@@ -1,0 +1,15 @@
+(* class_lib.ml *)
+class int_stack =
+  object
+    val mutable l : int list = []
+    method push x = l <- x::l
+    method pop =
+      match l with
+      | [] -> ()
+      | _::tl -> l <- tl
+    method peek =
+      match l with
+      | [] -> None
+      | hd::_ -> Some hd
+    method reset = l <- []
+  end

--- a/examples/docs/methods/code_constructs/class/class_lib.mli
+++ b/examples/docs/methods/code_constructs/class/class_lib.mli
@@ -1,0 +1,8 @@
+(* class_lib.mli *)
+class int_stack :
+  object
+    method push : int -> unit
+    method pop : unit
+    method peek : int option
+    method reset : unit
+  end

--- a/examples/docs/methods/code_constructs/class_type/Makefile
+++ b/examples/docs/methods/code_constructs/class_type/Makefile
@@ -1,0 +1,12 @@
+SRC:=class_type_lib.mli class_type_lib.ml class_type_bin.ml
+
+all: build analyze
+
+build:
+	ocamlopt -bin-annot ${SRC}
+
+analyze:
+	dead_code_analyzer --nothing -M all .
+
+clean:
+	rm -f *.cm* *.o a.out

--- a/examples/docs/methods/code_constructs/class_type/class_type_bin.ml
+++ b/examples/docs/methods/code_constructs/class_type/class_type_bin.ml
@@ -1,0 +1,15 @@
+(* class_type_bin.ml *)
+class type unused_class_type = object method unused_method : unit end
+
+let push_n_times n stack =
+  for i = 1 to n do
+    stack#push i;
+  done
+
+let () =
+  let open Class_type_lib in
+  let n = 42 in
+  push_n_times n int_stack;
+  while int_stack#peek <> None do
+    int_stack#pop;
+  done

--- a/examples/docs/methods/code_constructs/class_type/class_type_lib.ml
+++ b/examples/docs/methods/code_constructs/class_type/class_type_lib.ml
@@ -1,0 +1,23 @@
+(* class_type_lib.ml *)
+class type int_stack =
+  object
+    method push : int -> unit
+    method pop : unit
+    method peek : int option
+    method reset : unit
+  end
+
+let int_stack =
+  object
+    val mutable l : int list = []
+    method push x = l <- x::l
+    method pop =
+      match l with
+      | [] -> ()
+      | _::tl -> l <- tl
+    method peek =
+      match l with
+      | [] -> None
+      | hd::_ -> Some hd
+    method reset = l <- []
+  end

--- a/examples/docs/methods/code_constructs/class_type/class_type_lib.mli
+++ b/examples/docs/methods/code_constructs/class_type/class_type_lib.mli
@@ -1,0 +1,10 @@
+(* class_type_lib.mli *)
+class type int_stack =
+  object
+    method push : int -> unit
+    method pop : unit
+    method peek : int option
+    method reset : unit
+  end
+
+val int_stack : int_stack

--- a/examples/docs/methods/code_constructs/coercion/Makefile
+++ b/examples/docs/methods/code_constructs/coercion/Makefile
@@ -1,0 +1,12 @@
+SRC:=coercion_lib.mli coercion_lib.ml coercion_bin.ml
+
+all: build analyze
+
+build:
+	ocamlopt -bin-annot ${SRC}
+
+analyze:
+	dead_code_analyzer --nothing -M all .
+
+clean:
+	rm -f *.cm* *.o a.out

--- a/examples/docs/methods/code_constructs/coercion/coercion_bin.ml
+++ b/examples/docs/methods/code_constructs/coercion/coercion_bin.ml
@@ -1,0 +1,6 @@
+(* coercion_bin.ml *)
+open Coercion_lib
+
+let () =
+  let _coerce = (obj :> < used_by_requirement : unit >) in
+  ()

--- a/examples/docs/methods/code_constructs/coercion/coercion_lib.ml
+++ b/examples/docs/methods/code_constructs/coercion/coercion_lib.ml
@@ -1,0 +1,6 @@
+(* coercion_lib.ml *)
+let obj =
+  object
+    method used_by_requirement = ()
+    method unused = ()
+  end

--- a/examples/docs/methods/code_constructs/coercion/coercion_lib.mli
+++ b/examples/docs/methods/code_constructs/coercion/coercion_lib.mli
@@ -1,0 +1,5 @@
+(* coercion_lib.mli *)
+val obj :
+  < used_by_requirement : unit
+  ; unused : unit
+  >

--- a/examples/docs/methods/code_constructs/constructor/Makefile
+++ b/examples/docs/methods/code_constructs/constructor/Makefile
@@ -1,0 +1,12 @@
+SRC:=constructor_lib.mli constructor_lib.ml constructor_bin.ml
+
+all: build analyze
+
+build:
+	ocamlopt -bin-annot ${SRC}
+
+analyze:
+	dead_code_analyzer --nothing -M all .
+
+clean:
+	rm -f *.cm* *.o a.out

--- a/examples/docs/methods/code_constructs/constructor/constructor_bin.ml
+++ b/examples/docs/methods/code_constructs/constructor/constructor_bin.ml
@@ -1,0 +1,15 @@
+(* constructor_bin.ml *)
+class unused_class _ = object method unused_method = () end
+
+let push_n_times n stack =
+  for i = 1 to n do
+    stack#push i;
+  done
+
+let () =
+  let int_stack = new Constructor_lib.int_stack [] in
+  let n = 42 in
+  push_n_times n int_stack;
+  while int_stack#peek <> None do
+    int_stack#pop;
+  done

--- a/examples/docs/methods/code_constructs/constructor/constructor_lib.ml
+++ b/examples/docs/methods/code_constructs/constructor/constructor_lib.ml
@@ -1,0 +1,15 @@
+(* constructor_lib.ml *)
+class int_stack init =
+  object
+    val mutable l : int list = init
+    method push x = l <- x::l
+    method pop =
+      match l with
+      | [] -> ()
+      | _::tl -> l <- tl
+    method peek =
+      match l with
+      | [] -> None
+      | hd::_ -> Some hd
+    method reset = l <- []
+  end

--- a/examples/docs/methods/code_constructs/constructor/constructor_lib.mli
+++ b/examples/docs/methods/code_constructs/constructor/constructor_lib.mli
@@ -1,0 +1,9 @@
+(* constructor_lib.mli *)
+class int_stack :
+  int list ->
+  object
+    method push : int -> unit
+    method pop : unit
+    method peek : int option
+    method reset : unit
+  end

--- a/examples/docs/methods/code_constructs/factory_fun/Makefile
+++ b/examples/docs/methods/code_constructs/factory_fun/Makefile
@@ -1,0 +1,12 @@
+SRC:=factory_fun_lib.mli factory_fun_lib.ml factory_fun_bin.ml
+
+all: build analyze
+
+build:
+	ocamlopt -bin-annot ${SRC}
+
+analyze:
+	dead_code_analyzer --nothing -M all .
+
+clean:
+	rm -f *.cm* *.o a.out

--- a/examples/docs/methods/code_constructs/factory_fun/factory_fun_bin.ml
+++ b/examples/docs/methods/code_constructs/factory_fun/factory_fun_bin.ml
@@ -1,0 +1,15 @@
+(* factoy_fun_bin.ml *)
+let unused_factory () = object method unused_method = () end
+
+let push_n_times n stack =
+  for i = 1 to n do
+    stack#push i;
+  done
+
+let () =
+  let open Factory_fun_lib in
+  let n = 42 in
+  push_n_times n (get_stack ());
+  while (get_stack ())#peek <> None do
+    (get_stack ())#pop;
+  done

--- a/examples/docs/methods/code_constructs/factory_fun/factory_fun_lib.ml
+++ b/examples/docs/methods/code_constructs/factory_fun/factory_fun_lib.ml
@@ -1,0 +1,16 @@
+(* factoy_fun_lib.ml *)
+let stack = ref []
+
+let get_stack () =
+  object
+    method push x = stack := x::!stack
+    method pop =
+      match !stack with
+      | [] -> ()
+      | _::tl -> stack := tl
+    method peek =
+      match !stack with
+      | [] -> None
+      | hd::_ -> Some hd
+    method reset = stack := []
+  end

--- a/examples/docs/methods/code_constructs/factory_fun/factory_fun_lib.mli
+++ b/examples/docs/methods/code_constructs/factory_fun/factory_fun_lib.mli
@@ -1,0 +1,8 @@
+(* factoy_fun_lib.mli *)
+val get_stack :
+  unit ->
+  < push : int -> unit
+  ; pop : unit
+  ; peek : int option
+  ; reset : unit
+  >

--- a/examples/docs/methods/code_constructs/immediate_object/Makefile
+++ b/examples/docs/methods/code_constructs/immediate_object/Makefile
@@ -1,0 +1,12 @@
+SRC:=immediate_object_lib.mli immediate_object_lib.ml immediate_object_bin.ml
+
+all: build analyze
+
+build:
+	ocamlopt -bin-annot ${SRC}
+
+analyze:
+	dead_code_analyzer --nothing -M all .
+
+clean:
+	rm -f *.cm* *.o a.out

--- a/examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml
+++ b/examples/docs/methods/code_constructs/immediate_object/immediate_object_bin.ml
@@ -1,0 +1,15 @@
+(* immediate_object_bin.ml *)
+let unused_obj = object method unused_method = () end
+
+let push_n_times n stack =
+  for i = 1 to n do
+    stack#push i;
+  done
+
+let () =
+  let open Immediate_object_lib in
+  let n = 42 in
+  push_n_times n int_stack;
+  while int_stack#peek <> None do
+    int_stack#pop;
+  done

--- a/examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.ml
+++ b/examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.ml
@@ -1,0 +1,15 @@
+(* immediate_object_lib.ml *)
+let int_stack =
+  object
+    val mutable l = []
+    method push x = l <- x::l
+    method pop =
+      match l with
+      | [] -> ()
+      | _::tl -> l <- tl
+    method peek =
+      match l with
+      | [] -> None
+      | hd::_ -> Some hd
+    method reset = l <- []
+  end

--- a/examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli
+++ b/examples/docs/methods/code_constructs/immediate_object/immediate_object_lib.mli
@@ -1,0 +1,7 @@
+(* immediate_object_lib.mli *)
+val int_stack :
+  < push : int -> unit
+  ; pop : unit
+  ; peek : int option
+  ; reset : unit
+  >

--- a/examples/docs/methods/code_constructs/inheritance/Makefile
+++ b/examples/docs/methods/code_constructs/inheritance/Makefile
@@ -1,0 +1,12 @@
+SRC:=inheritance_lib.mli inheritance_lib.ml inheritance_bin.ml
+
+all: build analyze
+
+build:
+	ocamlopt -bin-annot ${SRC}
+
+analyze:
+	dead_code_analyzer --nothing -M all .
+
+clean:
+	rm -f *.cm* *.o a.out

--- a/examples/docs/methods/code_constructs/inheritance/inheritance_bin.ml
+++ b/examples/docs/methods/code_constructs/inheritance/inheritance_bin.ml
@@ -1,0 +1,6 @@
+(* inheritance_bin.ml *)
+let () =
+  let p = new Inheritance_lib.parent in
+  let c = new Inheritance_lib.child in
+  p#used;
+  c#used_by_child

--- a/examples/docs/methods/code_constructs/inheritance/inheritance_lib.ml
+++ b/examples/docs/methods/code_constructs/inheritance/inheritance_lib.ml
@@ -1,0 +1,12 @@
+(* inheritance_lib.ml *)
+class parent =
+  object
+    method unused = ()
+    method used = ()
+    method used_by_child = ()
+  end
+
+class child =
+  object
+    inherit parent
+  end

--- a/examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli
+++ b/examples/docs/methods/code_constructs/inheritance/inheritance_lib.mli
@@ -1,0 +1,12 @@
+(* inheritance_lib.mli *)
+class parent :
+  object
+    method unused : unit
+    method used : unit
+    method used_by_child : unit
+  end
+
+class child :
+  object
+    inherit parent
+  end

--- a/examples/docs/methods/code_constructs/object_type/Makefile
+++ b/examples/docs/methods/code_constructs/object_type/Makefile
@@ -1,0 +1,12 @@
+SRC:=object_type_lib.mli object_type_lib.ml object_type_bin.ml
+
+all: build analyze
+
+build:
+	ocamlopt -bin-annot ${SRC}
+
+analyze:
+	dead_code_analyzer --nothing -M all .
+
+clean:
+	rm -f *.cm* *.o a.out

--- a/examples/docs/methods/code_constructs/object_type/object_type_bin.ml
+++ b/examples/docs/methods/code_constructs/object_type/object_type_bin.ml
@@ -1,0 +1,15 @@
+(* object_type_bin.ml *)
+type unused_t = < unused_method : unit >
+
+let push_n_times n stack =
+  for i = 1 to n do
+    stack#push i;
+  done
+
+let () =
+  let open Object_type_lib in
+  let n = 42 in
+  push_n_times n int_stack;
+  while int_stack#peek <> None do
+    int_stack#pop;
+  done

--- a/examples/docs/methods/code_constructs/object_type/object_type_lib.ml
+++ b/examples/docs/methods/code_constructs/object_type/object_type_lib.ml
@@ -1,0 +1,22 @@
+(* object_type_lib.ml *)
+type int_stack =
+  < push : int -> unit
+  ; pop : unit
+  ; peek : int option
+  ; reset : unit
+  >
+
+let int_stack =
+  object
+    val mutable l : int list = []
+    method push x = l <- x::l
+    method pop =
+      match l with
+      | [] -> ()
+      | _::tl -> l <- tl
+    method peek =
+      match l with
+      | [] -> None
+      | hd::_ -> Some hd
+    method reset = l <- []
+  end

--- a/examples/docs/methods/code_constructs/object_type/object_type_lib.mli
+++ b/examples/docs/methods/code_constructs/object_type/object_type_lib.mli
@@ -1,0 +1,9 @@
+(* object_type_lib.mli *)
+type int_stack =
+  < push : int -> unit
+  ; pop : unit
+  ; peek : int option
+  ; reset : unit
+  >
+
+val int_stack : int_stack

--- a/examples/docs/methods/code_constructs/polymorphic_class/Makefile
+++ b/examples/docs/methods/code_constructs/polymorphic_class/Makefile
@@ -1,0 +1,12 @@
+SRC:=polymorphic_class_lib.mli polymorphic_class_lib.ml polymorphic_class_bin.ml
+
+all: build analyze
+
+build:
+	ocamlopt -bin-annot ${SRC}
+
+analyze:
+	dead_code_analyzer --nothing -M all .
+
+clean:
+	rm -f *.cm* *.o a.out

--- a/examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_bin.ml
+++ b/examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_bin.ml
@@ -1,0 +1,13 @@
+(* polymorphic_class_bin.ml *)
+let push_n_times n stack =
+  for i = 1 to n do
+    stack#push i;
+  done
+
+let () =
+  let int_stack = new Polymorphic_class_lib.stack in
+  let n = 42 in
+  push_n_times n int_stack;
+  while int_stack#peek <> None do
+    int_stack#pop;
+  done

--- a/examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_lib.ml
+++ b/examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_lib.ml
@@ -1,0 +1,15 @@
+(* polymorphic_class_lib.ml *)
+class ['a] stack =
+  object
+    val mutable l : 'a list = []
+    method push x = l <- x::l
+    method pop =
+      match l with
+      | [] -> ()
+      | _::tl -> l <- tl
+    method peek =
+      match l with
+      | [] -> None
+      | hd::_ -> Some hd
+    method reset = l <- []
+  end

--- a/examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_lib.mli
+++ b/examples/docs/methods/code_constructs/polymorphic_class/polymorphic_class_lib.mli
@@ -1,0 +1,8 @@
+(* polymorphic_class_lib.mli *)
+class ['a] stack :
+  object
+    method push : 'a -> unit
+    method pop : unit
+    method peek : 'a option
+    method reset : unit
+  end

--- a/examples/docs/methods/limitations/Makefile
+++ b/examples/docs/methods/limitations/Makefile
@@ -1,0 +1,11 @@
+.PHONY: clean build
+
+all: build
+
+build:
+	make -C alias build
+
+clean:
+	rm -f *~ *.cm* *.o *.obj
+	make -C alias clean
+

--- a/examples/docs/methods/limitations/Makefile
+++ b/examples/docs/methods/limitations/Makefile
@@ -4,8 +4,10 @@ all: build
 
 build:
 	make -C alias build
+	make -C factory_fun_indir build
 
 clean:
 	rm -f *~ *.cm* *.o *.obj
 	make -C alias clean
+	make -C factory_fun_indir clean
 

--- a/examples/docs/methods/limitations/alias/Makefile
+++ b/examples/docs/methods/limitations/alias/Makefile
@@ -1,0 +1,12 @@
+SRC:=alias_lib.mli alias_lib.ml alias_bin.ml
+
+all: build analyze
+
+build:
+	ocamlopt -bin-annot ${SRC}
+
+analyze:
+	dead_code_analyzer --nothing -M all .
+
+clean:
+	rm -f *.cm* *.o a.out

--- a/examples/docs/methods/limitations/alias/alias_bin.ml
+++ b/examples/docs/methods/limitations/alias/alias_bin.ml
@@ -1,0 +1,6 @@
+(* alias_bin.ml *)
+open Alias_lib
+
+let () =
+  original#used;
+  alias#used_by_alias

--- a/examples/docs/methods/limitations/alias/alias_lib.ml
+++ b/examples/docs/methods/limitations/alias/alias_lib.ml
@@ -1,0 +1,9 @@
+(* alias_lib.ml *)
+let original =
+  object
+    method used = ()
+    method used_by_alias = ()
+    method unused = ()
+  end
+
+let alias = original

--- a/examples/docs/methods/limitations/alias/alias_lib.mli
+++ b/examples/docs/methods/limitations/alias/alias_lib.mli
@@ -1,0 +1,12 @@
+(* alias_lib.mli *)
+val original :
+  < used : unit
+  ; used_by_alias : unit
+  ; unused : unit
+  >
+
+val alias :
+  < used : unit
+  ; used_by_alias : unit
+  ; unused : unit
+  >

--- a/examples/docs/methods/limitations/factory_fun_indir/Makefile
+++ b/examples/docs/methods/limitations/factory_fun_indir/Makefile
@@ -1,0 +1,12 @@
+SRC:=factory_fun_indir.ml
+
+all: build analyze
+
+build:
+	ocamlopt -bin-annot ${SRC}
+
+analyze:
+	dead_code_analyzer --nothing -M all .
+
+clean:
+	rm -f *.cm* *.o a.out

--- a/examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml
+++ b/examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml
@@ -1,0 +1,13 @@
+(* factoy_fun_indir.ml *)
+let factory_with_intermediate_binding () =
+  let res =
+    object method unused_method = () end
+  in
+  res
+
+let random_factory () =
+  if Random.bool () then
+    object method m = () end
+  else
+    let res = object method m = () end in
+    res


### PR DESCRIPTION
Fix https://github.com/LexiFi/dead_code_analyzer/issues/59

The new documentation provides some preliminary definitions to understand what the analyzer tracks and may report in the methods section.
It also provides examples focusing on different simple code constructs (classes, inheritance, coercion, ...), and document known limitations.

The code of the examples explored in the .md files is also provided in its own files to ease user experimentation, and is included in the testsuite.