### PR TITLE
Add doc for fields and constructors

### DIFF
--- a/check/classic/classic.exp
+++ b/check/classic/classic.exp
@@ -240,6 +240,9 @@ Nothing else to report in this section
 ====================================
 ./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:4: gadt.Float
 
+./examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.mli:4: t.Left
+./examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.mli:5: t.Right
+
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Right
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.left
 

--- a/check/classic/classic.exp
+++ b/check/classic/classic.exp
@@ -238,6 +238,8 @@ Nothing else to report in this section
 
 .> UNUSED CONSTRUCTORS/RECORD FIELDS:
 ====================================
+./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:4: gadt.Float
+
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Right
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.left
 

--- a/check/classic/classic.exp
+++ b/check/classic/classic.exp
@@ -238,6 +238,9 @@ Nothing else to report in this section
 
 .> UNUSED CONSTRUCTORS/RECORD FIELDS:
 ====================================
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Right
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.left
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:14: constructors.Unused
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:19: constr_with_eq.Unused
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:23: record.unused

--- a/check/classic/classic.ref
+++ b/check/classic/classic.ref
@@ -245,6 +245,9 @@ Nothing else to report in this section
 ====================================
 ./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:4: gadt.Float
 
+./examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.mli:4: t.Left
+./examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.mli:5: t.Right
+
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Right
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.left
 
@@ -661,7 +664,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 560
-Success: 553
+Total: 562
+Success: 555
 Failed: 7
-Ratio: 98.75%
+Ratio: 98.7544483986%

--- a/check/classic/classic.ref
+++ b/check/classic/classic.ref
@@ -243,6 +243,8 @@ Nothing else to report in this section
 
 .> UNUSED CONSTRUCTORS/RECORD FIELDS:
 ====================================
+./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:4: gadt.Float
+
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Right
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.left
 
@@ -659,7 +661,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 559
-Success: 552
+Total: 560
+Success: 553
 Failed: 7
-Ratio: 98.747763864%
+Ratio: 98.75%

--- a/check/classic/classic.ref
+++ b/check/classic/classic.ref
@@ -243,6 +243,9 @@ Nothing else to report in this section
 
 .> UNUSED CONSTRUCTORS/RECORD FIELDS:
 ====================================
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Right
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.left
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:14: constructors.Unused
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:19: constr_with_eq.Unused
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:23: record.unused
@@ -656,7 +659,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 557
-Success: 550
+Total: 559
+Success: 552
 Failed: 7
-Ratio: 98.7432675045%
+Ratio: 98.747763864%

--- a/check/internal/internal.exp
+++ b/check/internal/internal.exp
@@ -193,6 +193,9 @@ Nothing else to report in this section
 
 .> UNUSED CONSTRUCTORS/RECORD FIELDS:
 ====================================
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Right
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.left
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:14: constructors.Unused
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:19: constr_with_eq.Unused
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:23: record.unused

--- a/check/internal/internal.exp
+++ b/check/internal/internal.exp
@@ -193,6 +193,8 @@ Nothing else to report in this section
 
 .> UNUSED CONSTRUCTORS/RECORD FIELDS:
 ====================================
+./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:4: gadt.Float
+
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Right
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.left
 

--- a/check/internal/internal.exp
+++ b/check/internal/internal.exp
@@ -195,6 +195,9 @@ Nothing else to report in this section
 ====================================
 ./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:4: gadt.Float
 
+./examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.mli:4: t.Left
+./examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.mli:5: t.Right
+
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Right
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.left
 

--- a/check/internal/internal.ref
+++ b/check/internal/internal.ref
@@ -200,6 +200,9 @@ Nothing else to report in this section
 ====================================
 ./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:4: gadt.Float
 
+./examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.mli:4: t.Left
+./examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.mli:5: t.Right
+
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Right
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.left
 
@@ -616,7 +619,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 518
-Success: 511
+Total: 520
+Success: 513
 Failed: 7
-Ratio: 98.6486486486%
+Ratio: 98.6538461538%

--- a/check/internal/internal.ref
+++ b/check/internal/internal.ref
@@ -198,6 +198,8 @@ Nothing else to report in this section
 
 .> UNUSED CONSTRUCTORS/RECORD FIELDS:
 ====================================
+./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:4: gadt.Float
+
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Right
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.left
 
@@ -614,7 +616,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 517
-Success: 510
+Total: 518
+Success: 511
 Failed: 7
-Ratio: 98.6460348162%
+Ratio: 98.6486486486%

--- a/check/internal/internal.ref
+++ b/check/internal/internal.ref
@@ -198,6 +198,9 @@ Nothing else to report in this section
 
 .> UNUSED CONSTRUCTORS/RECORD FIELDS:
 ====================================
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Right
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.left
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:14: constructors.Unused
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:19: constr_with_eq.Unused
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:23: record.unused
@@ -611,7 +614,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 515
-Success: 508
+Total: 517
+Success: 510
 Failed: 7
-Ratio: 98.640776699%
+Ratio: 98.6460348162%

--- a/check/threshold-1/threshold-1.exp
+++ b/check/threshold-1/threshold-1.exp
@@ -542,6 +542,9 @@ Nothing else to report in this section
 
 .> UNUSED CONSTRUCTORS/RECORD FIELDS:
 ====================================
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Right
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.left
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:14: constructors.Unused
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:19: constr_with_eq.Unused
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:23: record.unused
@@ -614,6 +617,9 @@ Nothing else to report in this section
 
 .>->  ALMOST UNUSED CONSTRUCTORS/RECORD FIELDS: Called 1 time(s):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Left
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.right
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:16: constructors.Internally_used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:17: constructors.Externally_used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:25: record.internally_used

--- a/check/threshold-1/threshold-1.exp
+++ b/check/threshold-1/threshold-1.exp
@@ -140,6 +140,9 @@
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:2: hello
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:3: goodbye
 
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_lib.mli:4: poly_of_int
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_lib.mli:6: float_opt_of_poly
+
 ./examples/docs/methods/code_constructs/class/class_bin.ml:4: push_n_times
 
 ./examples/docs/methods/code_constructs/class_type/class_type_bin.ml:4: push_n_times

--- a/check/threshold-1/threshold-1.exp
+++ b/check/threshold-1/threshold-1.exp
@@ -140,6 +140,9 @@
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:2: hello
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:3: goodbye
 
+./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:6: gadt_of_int
+./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:8: float_opt_of_gadt
+
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_lib.mli:4: poly_of_int
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_lib.mli:6: float_opt_of_poly
 
@@ -545,6 +548,8 @@ Nothing else to report in this section
 
 .> UNUSED CONSTRUCTORS/RECORD FIELDS:
 ====================================
+./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:4: gadt.Float
+
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Right
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.left
 
@@ -620,6 +625,8 @@ Nothing else to report in this section
 
 .>->  ALMOST UNUSED CONSTRUCTORS/RECORD FIELDS: Called 1 time(s):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:3: gadt.Int
+
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Left
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.right
 

--- a/check/threshold-1/threshold-1.exp
+++ b/check/threshold-1/threshold-1.exp
@@ -143,6 +143,8 @@
 ./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:6: gadt_of_int
 ./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:8: float_opt_of_gadt
 
+./examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.mli:7: get_left_opt
+
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_lib.mli:4: poly_of_int
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_lib.mli:6: float_opt_of_poly
 
@@ -550,6 +552,9 @@ Nothing else to report in this section
 ====================================
 ./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:4: gadt.Float
 
+./examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.mli:4: t.Left
+./examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.mli:5: t.Right
+
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Right
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.left
 
@@ -626,6 +631,8 @@ Nothing else to report in this section
 .>->  ALMOST UNUSED CONSTRUCTORS/RECORD FIELDS: Called 1 time(s):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:3: gadt.Int
+
+./examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.mli:3: t.Both
 
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Left
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.right

--- a/check/threshold-1/threshold-1.exp
+++ b/check/threshold-1/threshold-1.exp
@@ -140,6 +140,9 @@
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:2: hello
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:3: goodbye
 
+./examples/docs/fields_and_constructors/code_constructs/extensible_variant/extensible_variant_bin.ml:5: to_string_opt
+./examples/docs/fields_and_constructors/code_constructs/extensible_variant/extensible_variant_lib.mli:7: to_string_opt
+
 ./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:6: gadt_of_int
 ./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:8: float_opt_of_gadt
 

--- a/check/threshold-1/threshold-1.ref
+++ b/check/threshold-1/threshold-1.ref
@@ -145,6 +145,9 @@
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:2: hello
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:3: goodbye
 
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_lib.mli:4: poly_of_int
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_lib.mli:6: float_opt_of_poly
+
 ./examples/docs/methods/code_constructs/class/class_bin.ml:4: push_n_times
 
 ./examples/docs/methods/code_constructs/class_type/class_type_bin.ml:4: push_n_times
@@ -1039,7 +1042,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 879
-Success: 871
+Total: 881
+Success: 873
 Failed: 8
-Ratio: 99.0898748578%
+Ratio: 99.0919409762%

--- a/check/threshold-1/threshold-1.ref
+++ b/check/threshold-1/threshold-1.ref
@@ -148,6 +148,8 @@
 ./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:6: gadt_of_int
 ./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:8: float_opt_of_gadt
 
+./examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.mli:7: get_left_opt
+
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_lib.mli:4: poly_of_int
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_lib.mli:6: float_opt_of_poly
 
@@ -554,6 +556,9 @@ Nothing else to report in this section
 ====================================
 ./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:4: gadt.Float
 
+./examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.mli:4: t.Left
+./examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.mli:5: t.Right
+
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Right
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.left
 
@@ -630,6 +635,8 @@ Nothing else to report in this section
 .>->  ALMOST UNUSED CONSTRUCTORS/RECORD FIELDS: Called 1 time(s):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:3: gadt.Int
+
+./examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.mli:3: t.Both
 
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Left
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.right
@@ -1049,7 +1056,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 885
-Success: 877
+Total: 889
+Success: 881
 Failed: 8
-Ratio: 99.0960451977%
+Ratio: 99.1001124859%

--- a/check/threshold-1/threshold-1.ref
+++ b/check/threshold-1/threshold-1.ref
@@ -145,6 +145,9 @@
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:2: hello
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:3: goodbye
 
+./examples/docs/fields_and_constructors/code_constructs/extensible_variant/extensible_variant_bin.ml:5: to_string_opt
+./examples/docs/fields_and_constructors/code_constructs/extensible_variant/extensible_variant_lib.mli:7: to_string_opt
+
 ./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:6: gadt_of_int
 ./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:8: float_opt_of_gadt
 
@@ -1056,7 +1059,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 889
-Success: 881
+Total: 891
+Success: 883
 Failed: 8
-Ratio: 99.1001124859%
+Ratio: 99.1021324355%

--- a/check/threshold-1/threshold-1.ref
+++ b/check/threshold-1/threshold-1.ref
@@ -145,6 +145,9 @@
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:2: hello
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:3: goodbye
 
+./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:6: gadt_of_int
+./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:8: float_opt_of_gadt
+
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_lib.mli:4: poly_of_int
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_lib.mli:6: float_opt_of_poly
 
@@ -549,6 +552,8 @@ Nothing else to report in this section
 
 .> UNUSED CONSTRUCTORS/RECORD FIELDS:
 ====================================
+./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:4: gadt.Float
+
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Right
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.left
 
@@ -624,6 +629,8 @@ Nothing else to report in this section
 
 .>->  ALMOST UNUSED CONSTRUCTORS/RECORD FIELDS: Called 1 time(s):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:3: gadt.Int
+
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Left
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.right
 
@@ -1042,7 +1049,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 881
-Success: 873
+Total: 885
+Success: 877
 Failed: 8
-Ratio: 99.0919409762%
+Ratio: 99.0960451977%

--- a/check/threshold-1/threshold-1.ref
+++ b/check/threshold-1/threshold-1.ref
@@ -546,6 +546,9 @@ Nothing else to report in this section
 
 .> UNUSED CONSTRUCTORS/RECORD FIELDS:
 ====================================
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Right
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.left
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:14: constructors.Unused
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:19: constr_with_eq.Unused
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:23: record.unused
@@ -618,6 +621,9 @@ Nothing else to report in this section
 
 .>->  ALMOST UNUSED CONSTRUCTORS/RECORD FIELDS: Called 1 time(s):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Left
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.right
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:16: constructors.Internally_used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:17: constructors.Externally_used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:25: record.internally_used
@@ -1033,7 +1039,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 875
-Success: 867
+Total: 879
+Success: 871
 Failed: 8
-Ratio: 99.0857142857%
+Ratio: 99.0898748578%

--- a/check/threshold-3-0.5/threshold-3-0.5.exp
+++ b/check/threshold-3-0.5/threshold-3-0.5.exp
@@ -719,6 +719,9 @@ Nothing else to report in this section
 
 .> UNUSED CONSTRUCTORS/RECORD FIELDS:
 ====================================
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Right
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.left
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:14: constructors.Unused
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:19: constr_with_eq.Unused
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:23: record.unused
@@ -791,6 +794,9 @@ Nothing else to report in this section
 
 .>->  ALMOST UNUSED CONSTRUCTORS/RECORD FIELDS: Called 1 time(s):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Left
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.right
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:16: constructors.Internally_used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:17: constructors.Externally_used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:25: record.internally_used

--- a/check/threshold-3-0.5/threshold-3-0.5.exp
+++ b/check/threshold-3-0.5/threshold-3-0.5.exp
@@ -140,6 +140,9 @@
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:2: hello
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:3: goodbye
 
+./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:6: gadt_of_int
+./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:8: float_opt_of_gadt
+
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_lib.mli:4: poly_of_int
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_lib.mli:6: float_opt_of_poly
 
@@ -722,6 +725,8 @@ Nothing else to report in this section
 
 .> UNUSED CONSTRUCTORS/RECORD FIELDS:
 ====================================
+./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:4: gadt.Float
+
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Right
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.left
 
@@ -797,6 +802,8 @@ Nothing else to report in this section
 
 .>->  ALMOST UNUSED CONSTRUCTORS/RECORD FIELDS: Called 1 time(s):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:3: gadt.Int
+
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Left
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.right
 

--- a/check/threshold-3-0.5/threshold-3-0.5.exp
+++ b/check/threshold-3-0.5/threshold-3-0.5.exp
@@ -140,6 +140,9 @@
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:2: hello
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:3: goodbye
 
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_lib.mli:4: poly_of_int
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_lib.mli:6: float_opt_of_poly
+
 ./examples/docs/methods/code_constructs/class/class_bin.ml:4: push_n_times
 
 ./examples/docs/methods/code_constructs/class_type/class_type_bin.ml:4: push_n_times

--- a/check/threshold-3-0.5/threshold-3-0.5.exp
+++ b/check/threshold-3-0.5/threshold-3-0.5.exp
@@ -143,6 +143,8 @@
 ./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:6: gadt_of_int
 ./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:8: float_opt_of_gadt
 
+./examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.mli:7: get_left_opt
+
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_lib.mli:4: poly_of_int
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_lib.mli:6: float_opt_of_poly
 
@@ -727,6 +729,9 @@ Nothing else to report in this section
 ====================================
 ./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:4: gadt.Float
 
+./examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.mli:4: t.Left
+./examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.mli:5: t.Right
+
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Right
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.left
 
@@ -803,6 +808,8 @@ Nothing else to report in this section
 .>->  ALMOST UNUSED CONSTRUCTORS/RECORD FIELDS: Called 1 time(s):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:3: gadt.Int
+
+./examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.mli:3: t.Both
 
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Left
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.right

--- a/check/threshold-3-0.5/threshold-3-0.5.exp
+++ b/check/threshold-3-0.5/threshold-3-0.5.exp
@@ -140,6 +140,9 @@
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:2: hello
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:3: goodbye
 
+./examples/docs/fields_and_constructors/code_constructs/extensible_variant/extensible_variant_bin.ml:5: to_string_opt
+./examples/docs/fields_and_constructors/code_constructs/extensible_variant/extensible_variant_lib.mli:7: to_string_opt
+
 ./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:6: gadt_of_int
 ./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:8: float_opt_of_gadt
 

--- a/check/threshold-3-0.5/threshold-3-0.5.ref
+++ b/check/threshold-3-0.5/threshold-3-0.5.ref
@@ -145,6 +145,9 @@
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:2: hello
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:3: goodbye
 
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_lib.mli:4: poly_of_int
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_lib.mli:6: float_opt_of_poly
+
 ./examples/docs/methods/code_constructs/class/class_bin.ml:4: push_n_times
 
 ./examples/docs/methods/code_constructs/class_type/class_type_bin.ml:4: push_n_times
@@ -1438,7 +1441,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 1196
-Success: 1188
+Total: 1198
+Success: 1190
 Failed: 8
-Ratio: 99.3311036789%
+Ratio: 99.3322203673%

--- a/check/threshold-3-0.5/threshold-3-0.5.ref
+++ b/check/threshold-3-0.5/threshold-3-0.5.ref
@@ -723,6 +723,9 @@ Nothing else to report in this section
 
 .> UNUSED CONSTRUCTORS/RECORD FIELDS:
 ====================================
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Right
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.left
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:14: constructors.Unused
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:19: constr_with_eq.Unused
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:23: record.unused
@@ -795,6 +798,9 @@ Nothing else to report in this section
 
 .>->  ALMOST UNUSED CONSTRUCTORS/RECORD FIELDS: Called 1 time(s):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Left
+./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.right
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:16: constructors.Internally_used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:17: constructors.Externally_used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:25: record.internally_used
@@ -1432,7 +1438,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 1192
-Success: 1184
+Total: 1196
+Success: 1188
 Failed: 8
-Ratio: 99.3288590604%
+Ratio: 99.3311036789%

--- a/check/threshold-3-0.5/threshold-3-0.5.ref
+++ b/check/threshold-3-0.5/threshold-3-0.5.ref
@@ -148,6 +148,8 @@
 ./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:6: gadt_of_int
 ./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:8: float_opt_of_gadt
 
+./examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.mli:7: get_left_opt
+
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_lib.mli:4: poly_of_int
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_lib.mli:6: float_opt_of_poly
 
@@ -731,6 +733,9 @@ Nothing else to report in this section
 ====================================
 ./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:4: gadt.Float
 
+./examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.mli:4: t.Left
+./examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.mli:5: t.Right
+
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Right
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.left
 
@@ -807,6 +812,8 @@ Nothing else to report in this section
 .>->  ALMOST UNUSED CONSTRUCTORS/RECORD FIELDS: Called 1 time(s):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:3: gadt.Int
+
+./examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.mli:3: t.Both
 
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Left
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.right
@@ -1448,7 +1455,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 1202
-Success: 1194
+Total: 1206
+Success: 1198
 Failed: 8
-Ratio: 99.3344425957%
+Ratio: 99.3366500829%

--- a/check/threshold-3-0.5/threshold-3-0.5.ref
+++ b/check/threshold-3-0.5/threshold-3-0.5.ref
@@ -145,6 +145,9 @@
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:2: hello
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:3: goodbye
 
+./examples/docs/fields_and_constructors/code_constructs/extensible_variant/extensible_variant_bin.ml:5: to_string_opt
+./examples/docs/fields_and_constructors/code_constructs/extensible_variant/extensible_variant_lib.mli:7: to_string_opt
+
 ./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:6: gadt_of_int
 ./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:8: float_opt_of_gadt
 
@@ -1455,7 +1458,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 1206
-Success: 1198
+Total: 1208
+Success: 1200
 Failed: 8
-Ratio: 99.3366500829%
+Ratio: 99.3377483444%

--- a/check/threshold-3-0.5/threshold-3-0.5.ref
+++ b/check/threshold-3-0.5/threshold-3-0.5.ref
@@ -145,6 +145,9 @@
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:2: hello
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:3: goodbye
 
+./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:6: gadt_of_int
+./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:8: float_opt_of_gadt
+
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_lib.mli:4: poly_of_int
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_lib.mli:6: float_opt_of_poly
 
@@ -726,6 +729,8 @@ Nothing else to report in this section
 
 .> UNUSED CONSTRUCTORS/RECORD FIELDS:
 ====================================
+./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:4: gadt.Float
+
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Right
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.left
 
@@ -801,6 +806,8 @@ Nothing else to report in this section
 
 .>->  ALMOST UNUSED CONSTRUCTORS/RECORD FIELDS: Called 1 time(s):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+./examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:3: gadt.Int
+
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Left
 ./examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.right
 
@@ -1441,7 +1448,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 1198
-Success: 1190
+Total: 1202
+Success: 1194
 Failed: 8
-Ratio: 99.3322203673%
+Ratio: 99.3344425957%

--- a/docs/USER_DOC.md
+++ b/docs/USER_DOC.md
@@ -55,6 +55,7 @@ This documentation is split accross different topics:
 - [Usage](USAGE.md) describes the usage of the `dead_code_analyzer` and its options.
 - [Exported Values](exported_values/EXPORTED_VALUES.md) describes the semantics and usage of the "unused exported values" report section, and provides examples.
 - [Methods](methods/METHODS.md) describes the semantics and usage of the "unused methods" report section, and provides examples.
+- [Constructors/Record fields](fields_and_constructors/FIELDS_AND_CONSTRUCTORS.md) describes the semantics and usage of the "unused constructors/record fields" report section, and provides examples.
 
 
 ## Footnotes

--- a/docs/fields_and_constructors/FIELDS_AND_CONSTRUCTORS.md
+++ b/docs/fields_and_constructors/FIELDS_AND_CONSTRUCTORS.md
@@ -1,0 +1,223 @@
+# Table of contents
+
++ [Fields and constructors](#fields-and-constructors)
+    + [Definitions](#definitions)
+    + [Compiler warnings](#compiler-warnings)
+        + [Warning 37: unused-constructor](#warning-37-unused-constructor)
+        + [Warning 38: unused-extension](#warning-38-unused-extension)
+        + [Warning 69: unused-field](#warning-69-unused-field)
+    + [Usage](#usage)
+
+# Fields and constructors
+
+## Definitions
+
+A **constructor** is a named value of a variant type.
+
+A **field** is a named value inside a record type.
+
+An **exported** constructor or field is one that is is declared in its
+compilation unit's signature.
+
+A **private** field or constructor is one in a private record or variant type.
+A private type is declared using the `private` keyword.
+
+A **use** is either :
+- Applying a constructor.
+  E.g.
+  ```OCaml
+  type side = Left | Right
+
+  let make_left () = Left
+  ```
+  The constructor `Left` is applied in `make_left`.
+- Reading a field.
+  E.g.
+  ```OCaml
+  type point = {x : float; y : float}
+
+  let get_x p = p.x
+  ```
+  The field `point.x` is read in `get_x`.
+
+> [!IMPORTANT]
+> A **use** is **not**:
+> - De-structuring a constructor.
+>   E.g.
+>   ```OCaml
+>   type side = Left | Right
+>
+>   let string_of_side = function
+>     | Left -> "Left"
+>     | Right -> "Right"
+>   ```
+>   Constructors `Left` and `Right` are matched on but never applied.
+> - Writing to a field.
+>   E.g.
+>   ```OCaml
+>   type point = {x : float; y : float}
+>
+>   let make_point x y = {x; y}
+>   ```
+>   The fields `point.x` and `point.y` are written but never read.
+
+## Compiler warnings
+
+The analyzer reports unused exported fields and constructors, while the compiler
+reports unused unexported fields and constructors. They complement each other.
+The compiler also warns on unused private constructors (but not private fields
+since they can still be read). The analyzer's reports overlap with the compiler
+on unused exported private constructors.
+
+> [!TIP]
+> To obtain a list of available compiler warnings, use
+> `ocamlopt -warn-help`
+
+The compiler warnings related to unused fields and constructors are the 37, 38,
+and 69.
+The first one is for unexported constructors, the second for unexported fields.
+
+### Warning 37: unused-constructor
+
+This warning is disabled by default.
+It can be enabled by passing the `-w +37` to the compiler.
+
+Description:
+```
+37 [unused-constructor] Unused constructor. (since 4.00)
+```
+
+Example
+```OCaml
+(* warning37.mli *)
+```
+```OCaml
+(* warning37.ml *)
+type 'a opt = None | Some of 'a
+
+let is_some = function
+  | Some _ -> true
+  | _ -> false
+```
+```
+$ ocamlopt -w +37 warning37.mli warning37.ml
+File "warning37.ml", line 2, characters 14-18:
+2 | type 'a opt = None | Some of 'a
+                  ^^^^
+Warning 37 [unused-constructor]: unused constructor None.
+
+File "warning37.ml", line 2, characters 19-31:
+2 | type 'a opt = None | Some of 'a
+                       ^^^^^^^^^^^^
+Warning 37 [unused-constructor]: constructor Some is never used to build values.
+(However, this constructor appears in patterns.)
+```
+
+### Warning 38: unused-extension
+
+This warning is disabled by default.
+It can be enabled by passing the `-w +38` to the compiler.
+
+Description:
+```
+38 [unused-extension] Unused extension constructor. (since 4.00)
+```
+
+Example
+```OCaml
+(* warning38.mli *)
+```
+```OCaml
+(* warning38.ml *)
+type t = ..
+type t +=
+  | Int of int
+  | Float of float
+
+let is_int = function
+  | Int _ -> true
+  | _ -> false
+```
+```
+$ ocamlopt -w +38 warning38.mli warning38.ml
+File "warning38.ml", line 4, characters 2-14:
+4 |   | Int of int
+      ^^^^^^^^^^^^
+Warning 38 [unused-extension]: extension constructor Int is never used to build values.
+(However, this constructor appears in patterns.)
+
+File "warning38.ml", line 5, characters 2-18:
+5 |   | Float of float
+      ^^^^^^^^^^^^^^^^
+Warning 38 [unused-extension]: unused extension constructor Float
+```
+
+### Warning 69: unused-field
+
+This warning is disabled by default.
+It can be enabled by passing the `-w +69` to the compiler.
+
+Description:
+```
+69 [unused-field] Unused record field. (since 4.13)
+```
+
+Example:
+```OCaml
+(* warning69.mli *)
+```
+```OCaml
+(* warning69.ml *)
+type point = {x : float; y : float}
+
+let move_x p x = {p with x}
+```
+```
+$ ocamlopt -w +69 warning69.mli warning69.ml
+File "warning69.ml", line 2, characters 14-24:
+2 | type point = {x : float; y : float}
+                  ^^^^^^^^^^
+Warning 69 [unused-field]: record field x is never read.
+(However, this field is used to build or mutate values.)
+
+File "warning69.ml", line 2, characters 25-34:
+2 | type point = {x : float; y : float}
+                             ^^^^^^^^^
+Warning 69 [unused-field]: unused record field y.
+```
+
+## Usage
+
+Unused exported fields and records are reported by default.
+Their reports can be deactivated using the `--nothing` or `-T nothing`
+command line arguments.
+They can be reactivated by using the `--all` or `-T all` command line arguments.
+For more details about the command line arguments see [the more general Usage
+documentation](../USAGE.md).
+
+The report section looks like:
+```
+.> UNUSED CONSTRUCTORS/RECORD FIELDS:
+====================================
+filepath:line: type.value
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+```
+The report line format is `filepath:line: type.value` with `filepath` the absolute
+path to the file (`.mli` if available, `.ml` otherwise) where `value` is
+declared, `line` the line index in `filepath` at which `value` is declared,
+`type` the path of the record or variant type within its compilation unit
+(e.g. `M.t`) to which `value` belongs, and `value` the unused field or constructor.
+There can be any number of such lines.
+
+The expected resolution for an unused exported field or constructor is to remove
+it from its type's definition.
+
+The expected resolution for an unused exported value is to remove it from the
+`.mli` if there is one, and the `.ml`.
+
+> [!IMPORTANT]
+> Removing unused fields or constructors may lead to compilation errors, because
+> one had to write all the fields when building a record, and potentially match
+> on the constructors.

--- a/docs/fields_and_constructors/FIELDS_AND_CONSTRUCTORS.md
+++ b/docs/fields_and_constructors/FIELDS_AND_CONSTRUCTORS.md
@@ -69,7 +69,7 @@ A **use** is either :
 The analyzer reports unused exported fields and constructors, while the compiler
 reports unused unexported fields and constructors. They complement each other.
 The compiler also warns on unused private constructors (but not private fields
-since they can still be read). The analyzer's reports overlap with the compiler
+since they can still be read). The analyzer's reports overlap with the compiler's
 on unused exported private constructors.
 
 > [!TIP]
@@ -216,9 +216,6 @@ There can be any number of such lines.
 
 The expected resolution for an unused exported field or constructor is to remove
 it from its type's definition.
-
-The expected resolution for an unused exported value is to remove it from the
-`.mli` if there is one, and the `.ml`.
 
 > [!IMPORTANT]
 > Removing unused fields or constructors may lead to compilation errors, because

--- a/docs/fields_and_constructors/FIELDS_AND_CONSTRUCTORS.md
+++ b/docs/fields_and_constructors/FIELDS_AND_CONSTRUCTORS.md
@@ -231,6 +231,7 @@ The expected resolution for an unused exported value is to remove it from the
   examples dedicated to specific code constructs :
     - [Polymorphic type](./code_constructs/POLYMORPHIC_TYPE.md)
     - [Polymorphic variant](./code_constructs/POLYMORPHIC_VARIANT.md)
+    - [GADT](./code_constructs/GADT.md)
 
 # Limitations
 

--- a/docs/fields_and_constructors/FIELDS_AND_CONSTRUCTORS.md
+++ b/docs/fields_and_constructors/FIELDS_AND_CONSTRUCTORS.md
@@ -232,6 +232,7 @@ The expected resolution for an unused exported value is to remove it from the
     - [Polymorphic type](./code_constructs/POLYMORPHIC_TYPE.md)
     - [Polymorphic variant](./code_constructs/POLYMORPHIC_VARIANT.md)
     - [GADT](./code_constructs/GADT.md)
+    - [Extensible variant](./code_constructs/EXTENSIBLE_VARIANT.md)
     - [Inline record](./code_constructs/INLINE_RECORD.md)
 
 # Limitations
@@ -240,6 +241,14 @@ The expected resolution for an unused exported value is to remove it from the
 
 The analyzer does not keep track of polymorphic variants, as explained in the
 [Polymorphic variant](./code_constructs/POLYMORPHIC_VARIANT.md) example.
+
+If you have a strong need/desire for this feature, please feel free to
+[open an issue](https://github.com/LexiFi/dead_code_analyzer/issues/new)
+
+## Extensible variant
+
+The analyzer does not keep track of extensible variants, as explained in the
+[Extensible variant](./code_constructs/EXTENSIBLE_VARIANT.md) example.
 
 If you have a strong need/desire for this feature, please feel free to
 [open an issue](https://github.com/LexiFi/dead_code_analyzer/issues/new)

--- a/docs/fields_and_constructors/FIELDS_AND_CONSTRUCTORS.md
+++ b/docs/fields_and_constructors/FIELDS_AND_CONSTRUCTORS.md
@@ -7,6 +7,7 @@
         + [Warning 38: unused-extension](#warning-38-unused-extension)
         + [Warning 69: unused-field](#warning-69-unused-field)
     + [Usage](#usage)
++ [Examples](#examples)
 
 # Fields and constructors
 
@@ -221,3 +222,9 @@ The expected resolution for an unused exported value is to remove it from the
 > Removing unused fields or constructors may lead to compilation errors, because
 > one had to write all the fields when building a record, and potentially match
 > on the constructors.
+
+# Examples
+
+- The [code constructs](./code_constructs) directory contains a collection of
+  examples dedicated to specific code constructs :
+    - [Polymorphic type](./code_constructs/POLYMORPHIC_TYPE.md)

--- a/docs/fields_and_constructors/FIELDS_AND_CONSTRUCTORS.md
+++ b/docs/fields_and_constructors/FIELDS_AND_CONSTRUCTORS.md
@@ -232,6 +232,7 @@ The expected resolution for an unused exported value is to remove it from the
     - [Polymorphic type](./code_constructs/POLYMORPHIC_TYPE.md)
     - [Polymorphic variant](./code_constructs/POLYMORPHIC_VARIANT.md)
     - [GADT](./code_constructs/GADT.md)
+    - [Inline record](./code_constructs/INLINE_RECORD.md)
 
 # Limitations
 
@@ -239,6 +240,14 @@ The expected resolution for an unused exported value is to remove it from the
 
 The analyzer does not keep track of polymorphic variants, as explained in the
 [Polymorphic variant](./code_constructs/POLYMORPHIC_VARIANT.md) example.
+
+If you have a strong need/desire for this feature, please feel free to
+[open an issue](https://github.com/LexiFi/dead_code_analyzer/issues/new)
+
+## Inline record
+
+The analyzer does not keep track of fields in inline records, as explained in
+the [Inline record](./code_constructs/INLINE_RECORD.md) example
 
 If you have a strong need/desire for this feature, please feel free to
 [open an issue](https://github.com/LexiFi/dead_code_analyzer/issues/new)

--- a/docs/fields_and_constructors/FIELDS_AND_CONSTRUCTORS.md
+++ b/docs/fields_and_constructors/FIELDS_AND_CONSTRUCTORS.md
@@ -8,6 +8,8 @@
         + [Warning 69: unused-field](#warning-69-unused-field)
     + [Usage](#usage)
 + [Examples](#examples)
++ [Limitations](#limitations)
+    + [Polymorphic variant](#polymorphic-variant)
 
 # Fields and constructors
 
@@ -228,3 +230,14 @@ The expected resolution for an unused exported value is to remove it from the
 - The [code constructs](./code_constructs) directory contains a collection of
   examples dedicated to specific code constructs :
     - [Polymorphic type](./code_constructs/POLYMORPHIC_TYPE.md)
+    - [Polymorphic variant](./code_constructs/POLYMORPHIC_VARIANT.md)
+
+# Limitations
+
+## Polymorphic variant
+
+The analyzer does not keep track of polymorphic variants, as explained in the
+[Polymorphic variant](./code_constructs/POLYMORPHIC_VARIANT.md) example.
+
+If you have a strong need/desire for this feature, please feel free to
+[open an issue](https://github.com/LexiFi/dead_code_analyzer/issues/new)

--- a/docs/fields_and_constructors/code_constructs/EXTENSIBLE_VARIANT.md
+++ b/docs/fields_and_constructors/code_constructs/EXTENSIBLE_VARIANT.md
@@ -1,0 +1,102 @@
+The reference files for this example are in the
+[extensible\_variant](../../../examples/docs/fields_and_constructors/code_constructs/extensible_variant) directory.
+
+The reference takes place in `/tmp/docs/fields_and_constructors/code_constructs`, which
+is a copy of the [code\_constructs](../../../examples/docs/fields_and_constructors/code_constructs)
+directory. Reported locations may differ depending on the location of the source
+files.
+
+The compilation command is :
+```
+make -C extensible_variant build
+```
+
+The analysis command is :
+```
+make -C extensible_variant analyze
+```
+
+The compile + analyze command is :
+```
+make -C extensible_variant
+```
+
+> [!IMPORTANT]
+> **LIMITATION**
+>
+> The analyzer ignores extensible variant constructors.
+
+## First run
+
+Code :
+```OCaml
+(* extensible_variant_lib.mli *)
+type t = ..
+type t +=
+  | Int of int
+  | Float of float
+
+val to_string_opt : t -> string option
+```
+```OCaml
+(* extensible_variant_lib.ml *)
+type t = ..
+type t +=
+  | Int of int
+  | Float of float
+
+let to_string_opt = function
+  | Int i -> Some (string_of_int i)
+  | Float f -> Some (string_of_float f)
+  | _ -> None
+```
+```OCaml
+(* extensible_variant_bin.ml *)
+open Extensible_variant_lib
+type t += String of string
+
+let to_string_opt = function
+  | String s -> Some s
+  | t -> to_string_opt t
+
+let () =
+  match to_string_opt (Int 42) with
+  | Some s -> print_endline s
+  | None -> ()
+
+```
+
+Before looking at the analysis results, let's look at the code.
+
+The `Extensible_variant_lib` deines 1 extensbile variant type `t` and adds 2
+constructors to it : `Int` and `Float`. `Extensible_variant_bin` adds another
+constructor to `t` : `String`. Of the 3 constructors, only `Int` is used to
+build a value. All of the constructors are matched on.
+Following the classical variant constructor semantics, `Int` is used while
+`Float` and `String are not.
+
+One could expect the analyzer to report `Float` and `String` as unused.
+However, the analyzer does not report unused extensible variant constructors.
+
+The compiler does report unused extensible variant constructors via warning 38.
+
+Compile and analyze :
+```
+$ make -C extensible_variant
+make: Entering directory '/tmp/docs/fields_and_constructors/code_constructs/extensible_variant'
+ocamlopt -w +38 -bin-annot extensible_variant_lib.mli extensible_variant_lib.ml extensible_variant_bin.ml
+dead_code_analyzer --nothing -T all .
+Scanning files...
+ [DONE]
+
+.> UNUSED CONSTRUCTORS/RECORD FIELDS:
+====================================
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/fields_and_constructors/code_constructs/extensible_variant'
+```
+
+As explained, nothing is reported. Our work here is done.

--- a/docs/fields_and_constructors/code_constructs/EXTENSIBLE_VARIANT.md
+++ b/docs/fields_and_constructors/code_constructs/EXTENSIBLE_VARIANT.md
@@ -68,12 +68,12 @@ let () =
 
 Before looking at the analysis results, let's look at the code.
 
-The `Extensible_variant_lib` deines 1 extensbile variant type `t` and adds 2
+The `Extensible_variant_lib` defines 1 extensbile variant type `t` and adds 2
 constructors to it : `Int` and `Float`. `Extensible_variant_bin` adds another
 constructor to `t` : `String`. Of the 3 constructors, only `Int` is used to
 build a value. All of the constructors are matched on.
 Following the classical variant constructor semantics, `Int` is used while
-`Float` and `String are not.
+`Float` and `String` are not.
 
 One could expect the analyzer to report `Float` and `String` as unused.
 However, the analyzer does not report unused extensible variant constructors.

--- a/docs/fields_and_constructors/code_constructs/GADT.md
+++ b/docs/fields_and_constructors/code_constructs/GADT.md
@@ -1,0 +1,187 @@
+The reference files for this example are in the
+[gadt](../../../examples/docs/fields_and_constructors/code_constructs/gadt) directory.
+
+The reference takes place in `/tmp/docs/fields_and_constructors/code_constructs`, which
+is a copy of the [code\_constructs](../../../examples/docs/fields_and_constructors/code_constructs)
+directory. Reported locations may differ depending on the location of the source
+files.
+
+The compilation command is :
+```
+make -C gadt build
+```
+
+The analysis command is :
+```
+make -C gadt analyze
+```
+
+The compile + analyze command is :
+```
+make -C gadt
+```
+
+## First run
+
+Code :
+```OCaml
+(* gadt_lib.mli *)
+type _ gadt =
+  | Int : int -> int gadt
+  | Float : float -> float gadt
+
+val gadt_of_int : int -> int gadt
+
+val float_opt_of_gadt : 'a gadt -> float option
+```
+```OCaml
+(* gadt_lib.ml *)
+type _ gadt =
+  | Int : int -> int gadt
+  | Float : float -> float gadt
+
+let gadt_of_int x = Int x
+
+let float_opt_of_gadt : type a . a gadt -> float option = function
+  | Float f -> Some f
+  | _ -> None
+```
+```OCaml
+(* gadt_bin.ml *)
+let () =
+  let open Gadt_lib in
+  let x = 0 in
+  let gadt = gadt_of_int x in
+  let f = float_opt_of_gadt gadt in
+  assert (f = None)
+```
+
+Before looking at the analysis results, let's look at the code.
+
+The `Gadt_lib` defines one gadt `gadt` with 2 constructors : `Int` and `Float`.
+The first one is used to construct values in `gadt_of_int`. The second one is
+matched on in `float_opt_of_gadt`.
+Following the classical variant constructor semantics, `Int` is used and `Float` is not.
+
+Compile and analyze :
+```
+$ make -C gadt
+make: Entering directory '/tmp/docs/fields_and_constructors/code_constructs/gadt'
+ocamlopt -w +37 -bin-annot gadt_lib.mli gadt_lib.ml gadt_bin.ml
+dead_code_analyzer --nothing -T all .
+Scanning files...
+ [DONE]
+
+.> UNUSED CONSTRUCTORS/RECORD FIELDS:
+====================================
+/tmp/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli:4: gadt.Float
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/fields_and_constructors/code_constructs/gadt'
+```
+
+As expected, the analyzer reports `gadt.Float` as unused.
+
+## Removing the unused constructor
+
+> [!TIP]
+> Do not forget to remove `gadt.Float` from both the `.mli` **and** the `.ml`.
+> Otherwise, the compiler will reject the code with a message like :
+> ```
+> File "gadt_lib.ml", line 1:
+> Error: The implementation gadt_lib.ml
+>        does not match the interface gadt_lib.mli:
+>        Type declarations do not match:
+>          type _ gadt = Int : int -> int gadt | Float : float -> float gadt
+>        is not included in
+>          type _ gadt = Int : int -> int gadt
+>        An extra constructor, Float, is provided in the first declaration.
+>        File "gadt_lib.mli", lines 2-3, characters 0-25: Expected declaration
+>        File "gadt_lib.ml", lines 2-4, characters 0-31: Actual declaration
+> ```
+
+After removing the unused constructor, the compiler will report errors at the
+locations were it was de-structured. Fixing those errors is simply done by
+removing the invalid pattern branches.
+
+Compile :
+```
+$ make -C gadt build
+make: Entering directory '/tmp/docs/fields_and_constructors/code_constructs/gadt'
+ocamlopt -w +37 -bin-annot gadt_lib.mli gadt_lib.ml gadt_bin.ml
+File "gadt_lib.ml", line 8, characters 4-9:
+8 |   | Float f -> Some f
+        ^^^^^
+Error: This variant pattern is expected to have type a gadt
+       There is no constructor Float within type gadt
+make: *** [Makefile:6: build] Error 2
+make: Leaving directory '/tmp/docs/fields_and_constructors/code_constructs/gadt'
+```
+Fix and compile :
+```
+$ make -C gadt build
+make: Entering directory '/tmp/docs/fields_and_constructors/code_constructs/gadt'
+ocamlopt -w +37 -bin-annot gadt_lib.mli gadt_lib.ml gadt_bin.ml
+make: Leaving directory '/tmp/docs/fields_and_constructors/code_constructs/gadt'
+```
+
+Compilation succeeds without error. Let's look at the code and analyze it.
+```OCaml
+(* gadt_lib.mli *)
+type _ gadt =
+  | Int : int -> int gadt
+
+val gadt_of_int : int -> int gadt
+
+val float_opt_of_gadt : 'a gadt -> float option
+```
+```OCaml
+(* gadt_lib.ml *)
+type _ gadt =
+  | Int : int -> int gadt
+
+let gadt_of_int x = Int x
+
+let float_opt_of_gadt : type a . a gadt -> float option = function
+  | _ -> None
+```
+```OCaml
+(* gadt_bin.ml *)
+let () =
+  let open Gadt_lib in
+  let x = 0 in
+  let gadt = gadt_of_int x in
+  let f = float_opt_of_gadt gadt in
+  assert (f = None)
+```
+
+Analyze :
+```
+$ make -C gadt analyze
+make: Entering directory '/tmp/docs/fields_and_constructors/code_constructs/gadt'
+dead_code_analyzer --nothing -T all .
+Scanning files...
+ [DONE]
+
+.> UNUSED CONSTRUCTORS/RECORD FIELDS:
+====================================
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/fields_and_constructors/code_constructs/gadt'
+```
+
+Neither the compiler nor the analyzer reports any unused constructor.
+Our work here is done.
+
+> [!NOTE]
+> The clean-up focused on the reports and the warnings. Of course, in the
+> context, the `float_opt_of_gadt` became meaningless because it always
+> produces `None`. Thus a user could decide to simply remove it and fix the
+> call-sites by either replacing the function call by `None` or any better
+> suited improvement.

--- a/docs/fields_and_constructors/code_constructs/GADT.md
+++ b/docs/fields_and_constructors/code_constructs/GADT.md
@@ -182,6 +182,6 @@ Our work here is done.
 > [!NOTE]
 > The clean-up focused on the reports and the warnings. Of course, in the
 > context, the `float_opt_of_gadt` became meaningless because it always
-> produces `None`. Thus a user could decide to simply remove it and fix the
+> produces `None`. Thus, a user could decide to simply remove it and fix the
 > call-sites by either replacing the function call by `None` or any better
 > suited improvement.

--- a/docs/fields_and_constructors/code_constructs/INLINE_RECORD.md
+++ b/docs/fields_and_constructors/code_constructs/INLINE_RECORD.md
@@ -1,0 +1,101 @@
+The reference files for this example are in the
+[inline\_record](../../../examples/docs/fields_and_constructors/code_constructs/inline_record) directory.
+
+The reference takes place in `/tmp/docs/fields_and_constructors/code_constructs`, which
+is a copy of the [code\_constructs](../../../examples/docs/fields_and_constructors/code_constructs)
+directory. Reported locations may differ depending on the location of the source
+files.
+
+The compilation command is :
+```
+make -C inline_record build
+```
+
+The analysis command is :
+```
+make -C inline_record analyze
+```
+
+The compile + analyze command is :
+```
+make -C inline_record
+```
+
+> [!IMPORTANT]
+> **LIMITATION**
+>
+> The analyzer ignores fields in inline records.
+
+## First run
+
+Code :
+```OCaml
+(* inline_record_lib.mli *)
+type ('a, 'b) t =
+  | Both of {left : 'a; right : 'b}
+  | Left of 'a
+  | Right of 'b
+
+val get_left_opt : ('a, 'b) t -> 'a option
+```
+```OCaml
+(* inline_record_lib.ml *)
+type ('a, 'b) t =
+  | Both of {left : 'a; right : 'b}
+  | Left of 'a
+  | Right of 'b
+
+let get_left_opt = function
+  | Both {left; _}
+  | Left left -> Some left
+  | _ -> None
+```
+```OCaml
+(* inline_record_bin.ml *)
+let () =
+  let open Inline_record_lib in
+  let both = Both {left = 1; right = "one"} in
+  match get_left_opt both with
+  | Some left -> assert (left = 1)
+  | _ -> assert false
+```
+
+Before looking at the analysis results, let's look at the code.
+
+The `Inline_record_lib` defines 1 variant type `t` with 3 constructors : `Both`,
+`Left`, and `Right`. Only the first one is used, the 2 others are only matched
+on in `get_left_opt`. Constructor `Both` has an inline record argument with 2
+fields : `left`, and `right`. Only the first one is used, the other one is only
+written to.
+Following the report semantics on constructors and fields, `Left`, `Right`, and
+`right` should be reported unused.
+
+However, the analyzer does not report unused inline record fields.
+The compiler also does not warn on unused inline record fields.
+
+Compile and analyze :
+```
+$ make -C inline_record
+make: Entering directory '/tmp/docs/fields_and_constructors/code_constructs/inline_record'
+ocamlopt -w +37+69 -bin-annot inline_record_lib.mli inline_record_lib.ml inline_record_bin.ml
+dead_code_analyzer --nothing -T all .
+Scanning files...
+ [DONE]
+
+.> UNUSED CONSTRUCTORS/RECORD FIELDS:
+====================================
+/tmp/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.mli:4: t.Left
+/tmp/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.mli:5: t.Right
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/fields_and_constructors/code_constructs/inline_record'
+```
+
+As expected, `t.Left`, and `t.Right` are reported unused by the analyzer.
+As explained, the analyzer does not report inline record fields so `right` is
+not reported.
+Fixing the unused constructors is the same as in the
+[Polymorphic type](./POLYMORPHIC_TYPE.md) example. Our work here is done.

--- a/docs/fields_and_constructors/code_constructs/POLYMORPHIC_TYPE.md
+++ b/docs/fields_and_constructors/code_constructs/POLYMORPHIC_TYPE.md
@@ -1,0 +1,291 @@
+The reference files for this example are in the
+[polymorphic\_type](../../../examples/docs/fields_and_constructors/code_constructs/polymorphic_type) directory.
+
+The reference takes place in `/tmp/docs/fields_and_constructors/code_constructs`, which
+is a copy of the [code\_constructs](../../../examples/docs/fields_and_constructors/code_constructs)
+directory. Reported locations may differ depending on the location of the source
+files.
+
+The compilation command is :
+```
+make -C polymorphic_type build
+```
+
+The analysis command is :
+```
+make -C polymorphic_type analyze
+```
+
+The compile + analyze command is :
+```
+make -C polymorphic_type
+```
+
+## First run
+
+Code:
+```OCaml
+(* polymorphic_type_lib.mli *)
+type ('a, 'b) either = Left of 'a | Right of 'b
+type ('a, 'b) both = {left : 'a; right : 'b}
+```
+```OCaml
+(* polymorphic_type_lib.ml *)
+type ('a, 'b) either = Left of 'a | Right of 'b
+type ('a, 'b) both = {left : 'a; right : 'b}
+```
+```OCaml
+(* polymorphic_type_bin.ml *)
+let () =
+  let open Polymorphic_type_lib in
+  let left = Left 1 in
+  let both = {left = 1; right = "one"} in
+  match left with
+  | Right x -> assert (x = both.right)
+  | _ -> ()
+```
+
+Before looking at the analysis results, let's look at the code.
+
+The `Polymorphic_type_lib` exports 1 variant type `either` with 2 constructors
+`Left` and `Right, and 1 record `both` with 2 fields `left` and `right.
+
+The constructor `Left` is used to build the value stored in `left`.
+The constructor `Right` is never built but matched upon. Thus, `Left` is used
+while `Right` is not.
+Both the fields `both.left` and `both.right` are written bu only the field
+`both.right` is read. This leaves `both.left` as unused.
+
+Compiler and analyze :
+```
+$ make: Entering directory '/tmp/docs/fields_and_constructors/code_constructs/polymorphic_type'
+ocamlopt -w +37+69 -bin-annot polymorphic_type_lib.mli polymorphic_type_lib.ml polymorphic_type_bin.ml
+dead_code_analyzer --nothing -T all .
+Scanning files...
+ [DONE]
+
+.> UNUSED CONSTRUCTORS/RECORD FIELDS:
+====================================
+/tmp/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:2: either.Right
+/tmp/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.left
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/fields_and_constructors/code_constructs/polymorphic_type'
+```
+
+As expected, constructor `either.Right` and field `both.left` are reported by
+the analyzer.
+
+## Removing the unused constructor and field
+
+> [!TIP]
+> Do not forget to remove `either.Right` from both the `.mli` **and** the `.ml`.
+> Otherwise, the compiler will reject the code with a message like :
+> ```
+> File "polymorphic_type_lib.ml", line 1:
+> Error: The implementation polymorphic_type_lib.ml
+>        does not match the interface polymorphic_type_lib.mli:
+>        Type declarations do not match:
+>          type ('a, 'b) either = Left of 'a | Right of 'b
+>        is not included in
+>          type ('a, 'b) either = Left of 'a
+>        An extra constructor, Right, is provided in the first declaration.
+>        File "polymorphic_type_lib.mli", line 2, characters 0-33:
+>          Expected declaration
+>        File "polymorphic_type_lib.ml", line 2, characters 0-47:
+>          Actual declaration
+> ```
+
+> [!TIP]
+> Do not forget to remove `both.left` from both the `.mli` **and** the `.ml`.
+> Otherwise, the compiler will reject the code with a message like :
+> ```
+> Error: The implementation polymorphic_type_lib.ml
+>        does not match the interface polymorphic_type_lib.mli:
+>        Type declarations do not match:
+>          type ('a, 'b) both = { left : 'a; right : 'b; }
+>        is not included in
+>          type ('a, 'b) both = { right : 'b; }
+>        An extra field, left, is provided in the first declaration.
+>        File "polymorphic_type_lib.mli", line 3, characters 0-33:
+>          Expected declaration
+>        File "polymorphic_type_lib.ml", line 3, characters 0-44:
+>          Actual declaration
+> ```
+
+After removing the unused constructor and field, the compiler will report errors
+at the locations were they are de-structured and written respectively.
+Fixing those errors is simply done by removing the invalid pattern branches and
+writes.
+
+Compile :
+```
+$ make -C polymorphic_type build
+make: Entering directory '/tmp/docs/fields_and_constructors/code_constructs/polymorphic_type'
+ocamlopt -w +37+69 -bin-annot polymorphic_type_lib.mli polymorphic_type_lib.ml polymorphic_type_bin.ml
+File "polymorphic_type_bin.ml", line 5, characters 14-18:
+5 |   let both = {left = 1; right = "one"} in
+                  ^^^^
+Error: Unbound record field left
+make: *** [Makefile:6: build] Error 2
+make: Leaving directory '/tmp/docs/fields_and_constructors/code_constructs/polymorphic_type'
+```
+Fix and compile :
+```
+$ make -C polymorphic_type build
+make: Entering directory '/tmp/docs/fields_and_constructors/code_constructs/polymorphic_type'
+ocamlopt -w +37+69 -bin-annot polymorphic_type_lib.mli polymorphic_type_lib.ml polymorphic_type_bin.ml
+File "polymorphic_type_bin.ml", line 7, characters 4-9:
+7 |   | Right x -> assert (x = both.right)
+        ^^^^^
+Error: This variant pattern is expected to have type
+         (int, 'a) Polymorphic_type_lib.either
+       There is no constructor Right within type Polymorphic_type_lib.either
+make: *** [Makefile:6: build] Error 2
+make: Leaving directory '/tmp/docs/fields_and_constructors/code_constructs/polymorphic_type'
+```
+Fix and compile :
+```
+$ make -C polymorphic_type build
+make: Entering directory '/tmp/docs/fields_and_constructors/code_constructs/polymorphic_type'
+ocamlopt -w +37+69 -bin-annot polymorphic_type_lib.mli polymorphic_type_lib.ml polymorphic_type_bin.ml
+File "polymorphic_type_bin.ml", line 5, characters 6-10:
+5 |   let both = {right = "one"} in
+          ^^^^
+Warning 26 [unused-var]: unused variable both.
+make: Leaving directory '/tmp/docs/fields_and_constructors/code_constructs/polymorphic_type'
+```
+
+Compilation succeeds without error. There is a warning on an unused variable.
+This topic is discussed in the
+[Exported values](../exported_values/EXPORTED_VALUES.md) section.
+
+Now we have removed the unused constructor and field, and fixed all the
+compilation errors. Let's look at the code and analyze it.
+
+Code :
+```OCaml
+(* polymorphic_type_lib.mli *)
+type ('a, 'b) either = Left of 'a
+type ('a, 'b) both = {right : 'b}
+```
+```OCaml
+(* polymorphic_type_lib.ml *)
+type ('a, 'b) either = Left of 'a
+type ('a, 'b) both = {right : 'b}
+```
+```OCaml
+(* polymorphic_type_bin.ml *)
+let () =
+  let open Polymorphic_type_lib in
+  let left = Left 1 in
+  let both = {right = "one"} in
+  match left with
+  | _ -> ()
+```
+
+Analyze :
+```
+$ make -C polymorphic_type analyze
+make: Entering directory '/tmp/docs/fields_and_constructors/code_constructs/polymorphic_type'
+dead_code_analyzer --nothing -T all .
+Scanning files...
+ [DONE]
+
+.> UNUSED CONSTRUCTORS/RECORD FIELDS:
+====================================
+/tmp/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli:3: both.right
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/fields_and_constructors/code_constructs/polymorphic_type'
+```
+
+The analyzer reports `both.right` as unused. This is coherent with the compiler
+warning above saying that variable `both` is unused  because it is the only
+value of type `both`.
+
+Let's fix both the compiler warning and the analyzer's report.
+
+## Removing the unused value and field
+
+Because `right` is the only field in `both`, removing the field necessitates
+either removing the type or making the type abstract. We will remove the type
+from the `.mli`
+
+> [!NOTE]
+> An empty record type is a syntax error :
+> ```
+> File "polymorphic_type_lib.mli", line 3, characters 23-24:
+> 3 | type ('a, 'b) both = { }
+>                            ^
+> Error: Syntax error
+> ```
+
+Code :
+```OCaml
+(* polymorphic_type_lib.mli *)
+type ('a, 'b) either = Left of 'a
+```
+```OCaml
+(* polymorphic_type_lib.ml *)
+type ('a, 'b) either = Left of 'a
+type ('a, 'b) both = {right : 'b}
+```
+```OCaml
+(* polymorphic_type_bin.ml *)
+let () =
+  let open Polymorphic_type_lib in
+  let left = Left 1 in
+  match left with
+  | _ -> ()
+```
+
+Compile and analyze :
+```
+$ make -C polymorphic_type
+make: Entering directory '/tmp/docs/fields_and_constructors/code_constructs/polymorphic_type'
+ocamlopt -w +37+69 -bin-annot polymorphic_type_lib.mli polymorphic_type_lib.ml polymorphic_type_bin.ml
+File "polymorphic_type_lib.ml", line 3, characters 22-32:
+3 | type ('a, 'b) both = {right : 'b}
+                          ^^^^^^^^^^
+Warning 69 [unused-field]: unused record field right.
+dead_code_analyzer --nothing -T all .
+Scanning files...
+ [DONE]
+
+.> UNUSED CONSTRUCTORS/RECORD FIELDS:
+====================================
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/fields_and_constructors/code_constructs/polymorphic_type'
+```
+
+The compiler warns us that the unuexported field `right` is unused.
+The analyzer does not report anything.
+
+Once again, the fix is to either make the type abstract or removing it from
+the `.ml`. We can do the latter and neither the compiler nor the analyzer will
+report any unused constructor or field. Our work here is done.
+
+> [!TIP]
+> If we activated the compiler warning 34 `unused-type-declaration`
+> (by passing the argument `-w +34`), and made `both` abstract in the `.ml`,
+> then the compiler would have reported.
+> ```
+> File "polymorphic_type_lib.ml", line 3, characters 0-18:
+> 3 | type ('a, 'b) both
+>     ^^^^^^^^^^^^^^^^^^
+> Warning 34 [unused-type-declaration]: unused type both.
+> ```
+> The analyzer does not have an unused exported type feature yet so making the
+> type abstract in the `.mli` would not have lead to any unused exported type
+> report.

--- a/docs/fields_and_constructors/code_constructs/POLYMORPHIC_TYPE.md
+++ b/docs/fields_and_constructors/code_constructs/POLYMORPHIC_TYPE.md
@@ -53,10 +53,10 @@ The `Polymorphic_type_lib` exports 1 variant type `either` with 2 constructors
 The constructor `Left` is used to build the value stored in `left`.
 The constructor `Right` is never built but matched upon. Thus, `Left` is used
 while `Right` is not.
-Both the fields `both.left` and `both.right` are written bu only the field
+Both the fields `both.left` and `both.right` are written but only the field
 `both.right` is read. This leaves `both.left` as unused.
 
-Compiler and analyze :
+Compile and analyze :
 ```
 $ make: Entering directory '/tmp/docs/fields_and_constructors/code_constructs/polymorphic_type'
 ocamlopt -w +37+69 -bin-annot polymorphic_type_lib.mli polymorphic_type_lib.ml polymorphic_type_bin.ml
@@ -269,17 +269,17 @@ Nothing else to report in this section
 make: Leaving directory '/tmp/docs/fields_and_constructors/code_constructs/polymorphic_type'
 ```
 
-The compiler warns us that the unuexported field `right` is unused.
+The compiler warns us that the unexported field `right` is unused.
 The analyzer does not report anything.
 
-Once again, the fix is to either make the type abstract or removing it from
+Once again, the fix is to either make the type abstract or remove it from
 the `.ml`. We can do the latter and neither the compiler nor the analyzer will
 report any unused constructor or field. Our work here is done.
 
 > [!TIP]
 > If we activated the compiler warning 34 `unused-type-declaration`
 > (by passing the argument `-w +34`), and made `both` abstract in the `.ml`,
-> then the compiler would have reported.
+> then the compiler would have reported it unused.
 > ```
 > File "polymorphic_type_lib.ml", line 3, characters 0-18:
 > 3 | type ('a, 'b) both

--- a/docs/fields_and_constructors/code_constructs/POLYMORPHIC_VARIANT.md
+++ b/docs/fields_and_constructors/code_constructs/POLYMORPHIC_VARIANT.md
@@ -1,0 +1,96 @@
+The reference files for this example are in the
+[polymorphic\_variant](../../../examples/docs/fields_and_constructors/code_constructs/polymorphic_variant) directory.
+
+The reference takes place in `/tmp/docs/fields_and_constructors/code_constructs`, which
+is a copy of the [code\_constructs](../../../examples/docs/fields_and_constructors/code_constructs)
+directory. Reported locations may differ depending on the location of the source
+files.
+
+The compilation command is :
+```
+make -C polymorphic_variant build
+```
+
+The analysis command is :
+```
+make -C polymorphic_variant analyze
+```
+
+The compile + analyze command is :
+```
+make -C polymorphic_variant
+```
+
+> [!IMPORTANT]
+> **LIMITATION**
+>
+> The analyzer ignores polymorphic variant constructors.
+
+## First run
+
+Code :
+```OCaml
+(* polymorphic_variant_lib.mli *)
+type poly = [`Int of int | `Float of float]
+
+val poly_of_int : int -> [> `Int of int]
+
+val float_opt_of_poly : poly -> float option
+```
+```OCaml
+(* polymorphic_variant_lib.ml *)
+type poly = [`Int of int | `Float of float]
+
+let poly_of_int x = `Int x
+
+let float_opt_of_poly = function
+  | `Float f -> Some f
+  | _ -> None
+```
+```OCaml
+(* polymorphic_variant_bin.ml *)
+let () =
+  let open Polymorphic_variant_lib in
+  let x = 0 in
+  let poly = poly_of_int x in
+  let f = float_opt_of_poly poly in
+  assert (f = None)
+```
+
+Before looking at the analysis results, let's look at the code.
+
+The `Polymorphic_variant_lib` uses 2 polymorphic variant constructors : `` `Int ``
+and `` `Float ``. The first one is built in `poly_of_int`. The second one is
+matched on in `float_opt_of_poly`.
+Following the classical variant constructor semantics, `` `Int `` is used and
+`` `Float `` is not.
+
+
+One could expect the analyzer to report `` `Float `` as unused. However, the
+analyzer does not report unused polymorphic variant constructors.
+Unlike regular variant constructors, polymorphic variant constructors do not
+belong to any specific type. That flexibility is their purpose. Currently,
+reporting a constructor requires that it is associated with a single type.
+
+The compiler also does not warn on unused polymorphic variant constructors.
+
+Compile and analyze :
+```
+$ make -C polymorphic_variant
+make: Entering directory '/tmp/docs/fields_and_constructors/code_constructs/polymorphic_variant'
+ocamlopt -w +37 -bin-annot polymorphic_variant_lib.mli polymorphic_variant_lib.ml polymorphic_variant_bin.ml
+dead_code_analyzer --nothing -T all .
+Scanning files...
+ [DONE]
+
+.> UNUSED CONSTRUCTORS/RECORD FIELDS:
+====================================
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/fields_and_constructors/code_constructs/polymorphic_variant'
+```
+
+As explained, nothing is reported. Our work here is done.

--- a/examples/docs/Makefile
+++ b/examples/docs/Makefile
@@ -5,9 +5,11 @@ all: build
 build:
 	make -C exported_values
 	make -C methods
+	make -C fields_and_constructors
 
 clean:
 	rm -f *~ *.cm* *.o *.obj
 	make -C exported_values clean
 	make -C methods clean
+	make -C fields_and_constructors clean
 

--- a/examples/docs/fields_and_constructors/Makefile
+++ b/examples/docs/fields_and_constructors/Makefile
@@ -1,0 +1,10 @@
+.PHONY: clean build
+
+all: build
+
+build:
+	make -C code_constructs
+
+clean:
+	rm -f *~ *.cm* *.o *.obj
+	make -C code_constructs clean

--- a/examples/docs/fields_and_constructors/code_constructs/Makefile
+++ b/examples/docs/fields_and_constructors/code_constructs/Makefile
@@ -6,9 +6,11 @@ build:
 	make -C polymorphic_type build
 	make -C polymorphic_variant build
 	make -C gadt build
+	make -C inline_record build
 
 clean:
 	rm -f *~ *.cm* *.o *.obj
 	make -C polymorphic_type clean
 	make -C polymorphic_variant clean
 	make -C gadt clean
+	make -C inline_record clean

--- a/examples/docs/fields_and_constructors/code_constructs/Makefile
+++ b/examples/docs/fields_and_constructors/code_constructs/Makefile
@@ -6,6 +6,7 @@ build:
 	make -C polymorphic_type build
 	make -C polymorphic_variant build
 	make -C gadt build
+	make -C extensible_variant build
 	make -C inline_record build
 
 clean:
@@ -13,4 +14,5 @@ clean:
 	make -C polymorphic_type clean
 	make -C polymorphic_variant clean
 	make -C gadt clean
+	make -C extensible_variant clean
 	make -C inline_record clean

--- a/examples/docs/fields_and_constructors/code_constructs/Makefile
+++ b/examples/docs/fields_and_constructors/code_constructs/Makefile
@@ -1,0 +1,10 @@
+.PHONY: clean build
+
+all: build
+
+build:
+	make -C polymorphic_type build
+
+clean:
+	rm -f *~ *.cm* *.o *.obj
+	make -C polymorphic_type clean

--- a/examples/docs/fields_and_constructors/code_constructs/Makefile
+++ b/examples/docs/fields_and_constructors/code_constructs/Makefile
@@ -4,7 +4,9 @@ all: build
 
 build:
 	make -C polymorphic_type build
+	make -C polymorphic_variant build
 
 clean:
 	rm -f *~ *.cm* *.o *.obj
 	make -C polymorphic_type clean
+	make -C polymorphic_variant clean

--- a/examples/docs/fields_and_constructors/code_constructs/Makefile
+++ b/examples/docs/fields_and_constructors/code_constructs/Makefile
@@ -5,8 +5,10 @@ all: build
 build:
 	make -C polymorphic_type build
 	make -C polymorphic_variant build
+	make -C gadt build
 
 clean:
 	rm -f *~ *.cm* *.o *.obj
 	make -C polymorphic_type clean
 	make -C polymorphic_variant clean
+	make -C gadt clean

--- a/examples/docs/fields_and_constructors/code_constructs/extensible_variant/Makefile
+++ b/examples/docs/fields_and_constructors/code_constructs/extensible_variant/Makefile
@@ -1,0 +1,12 @@
+SRC:=extensible_variant_lib.mli extensible_variant_lib.ml extensible_variant_bin.ml
+
+all: build analyze
+
+build:
+	ocamlopt -w +38 -bin-annot ${SRC}
+
+analyze:
+	dead_code_analyzer --nothing -T all .
+
+clean:
+	rm -f *.cm* *.o a.out

--- a/examples/docs/fields_and_constructors/code_constructs/extensible_variant/extensible_variant_bin.ml
+++ b/examples/docs/fields_and_constructors/code_constructs/extensible_variant/extensible_variant_bin.ml
@@ -1,0 +1,13 @@
+(* extensible_variant_bin.ml *)
+open Extensible_variant_lib
+type t += String of string
+
+let to_string_opt = function
+  | String s -> Some s
+  | t -> to_string_opt t
+
+let () =
+  match to_string_opt (Int 42) with
+  | Some s -> print_endline s
+  | None -> ()
+

--- a/examples/docs/fields_and_constructors/code_constructs/extensible_variant/extensible_variant_lib.ml
+++ b/examples/docs/fields_and_constructors/code_constructs/extensible_variant/extensible_variant_lib.ml
@@ -1,0 +1,10 @@
+(* extensible_variant_lib.ml *)
+type t = ..
+type t +=
+  | Int of int
+  | Float of float
+
+let to_string_opt = function
+  | Int i -> Some (string_of_int i)
+  | Float f -> Some (string_of_float f)
+  | _ -> None

--- a/examples/docs/fields_and_constructors/code_constructs/extensible_variant/extensible_variant_lib.mli
+++ b/examples/docs/fields_and_constructors/code_constructs/extensible_variant/extensible_variant_lib.mli
@@ -1,0 +1,7 @@
+(* extensible_variant_lib.mli *)
+type t = ..
+type t +=
+  | Int of int
+  | Float of float
+
+val to_string_opt : t -> string option

--- a/examples/docs/fields_and_constructors/code_constructs/gadt/Makefile
+++ b/examples/docs/fields_and_constructors/code_constructs/gadt/Makefile
@@ -1,0 +1,12 @@
+SRC:=gadt_lib.mli gadt_lib.ml gadt_bin.ml
+
+all: build analyze
+
+build:
+	ocamlopt -w +37 -bin-annot ${SRC}
+
+analyze:
+	dead_code_analyzer --nothing -T all .
+
+clean:
+	rm -f *.cm* *.o a.out

--- a/examples/docs/fields_and_constructors/code_constructs/gadt/gadt_bin.ml
+++ b/examples/docs/fields_and_constructors/code_constructs/gadt/gadt_bin.ml
@@ -1,0 +1,7 @@
+(* gadt_bin.ml *)
+let () =
+  let open Gadt_lib in
+  let x = 0 in
+  let gadt = gadt_of_int x in
+  let f = float_opt_of_gadt gadt in
+  assert (f = None)

--- a/examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.ml
+++ b/examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.ml
@@ -1,0 +1,10 @@
+(* gadt_lib.ml *)
+type _ gadt =
+  | Int : int -> int gadt
+  | Float : float -> float gadt
+
+let gadt_of_int x = Int x
+
+let float_opt_of_gadt : type a . a gadt -> float option = function
+  | Float f -> Some f
+  | _ -> None

--- a/examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli
+++ b/examples/docs/fields_and_constructors/code_constructs/gadt/gadt_lib.mli
@@ -1,0 +1,8 @@
+(* gadt_lib.mli *)
+type _ gadt =
+  | Int : int -> int gadt
+  | Float : float -> float gadt
+
+val gadt_of_int : int -> int gadt
+
+val float_opt_of_gadt : 'a gadt -> float option

--- a/examples/docs/fields_and_constructors/code_constructs/inline_record/Makefile
+++ b/examples/docs/fields_and_constructors/code_constructs/inline_record/Makefile
@@ -1,0 +1,12 @@
+SRC:=inline_record_lib.mli inline_record_lib.ml inline_record_bin.ml
+
+all: build analyze
+
+build:
+	ocamlopt -w +37+69 -bin-annot ${SRC}
+
+analyze:
+	dead_code_analyzer --nothing -T all .
+
+clean:
+	rm -f *.cm* *.o a.out

--- a/examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_bin.ml
+++ b/examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_bin.ml
@@ -1,0 +1,7 @@
+(* inline_record_bin.ml *)
+let () =
+  let open Inline_record_lib in
+  let both = Both {left = 1; right = "one"} in
+  match get_left_opt both with
+  | Some left -> assert (left = 1)
+  | _ -> assert false

--- a/examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.ml
+++ b/examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.ml
@@ -1,0 +1,10 @@
+(* inline_record_lib.ml *)
+type ('a, 'b) t =
+  | Both of {left : 'a; right : 'b}
+  | Left of 'a
+  | Right of 'b
+
+let get_left_opt = function
+  | Both {left; _}
+  | Left left -> Some left
+  | _ -> None

--- a/examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.mli
+++ b/examples/docs/fields_and_constructors/code_constructs/inline_record/inline_record_lib.mli
@@ -1,0 +1,7 @@
+(* inline_record_lib.mli *)
+type ('a, 'b) t =
+  | Both of {left : 'a; right : 'b}
+  | Left of 'a
+  | Right of 'b
+
+val get_left_opt : ('a, 'b) t -> 'a option

--- a/examples/docs/fields_and_constructors/code_constructs/polymorphic_type/Makefile
+++ b/examples/docs/fields_and_constructors/code_constructs/polymorphic_type/Makefile
@@ -1,0 +1,12 @@
+SRC:=polymorphic_type_lib.mli polymorphic_type_lib.ml polymorphic_type_bin.ml
+
+all: build analyze
+
+build:
+	ocamlopt -w +37+69 -bin-annot ${SRC}
+
+analyze:
+	dead_code_analyzer --nothing -T all .
+
+clean:
+	rm -f *.cm* *.o a.out

--- a/examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_bin.ml
+++ b/examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_bin.ml
@@ -1,0 +1,8 @@
+(* polymorphic_type_bin.ml *)
+let () =
+  let open Polymorphic_type_lib in
+  let left = Left 1 in
+  let both = {left = 1; right = "one"} in
+  match left with
+  | Right x -> assert (x = both.right)
+  | _ -> ()

--- a/examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.ml
+++ b/examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.ml
@@ -1,0 +1,3 @@
+(* polymorphic_type_lib.ml *)
+type ('a, 'b) either = Left of 'a | Right of 'b
+type ('a, 'b) both = {left : 'a; right : 'b}

--- a/examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli
+++ b/examples/docs/fields_and_constructors/code_constructs/polymorphic_type/polymorphic_type_lib.mli
@@ -1,0 +1,3 @@
+(* polymorphic_type_lib.mli *)
+type ('a, 'b) either = Left of 'a | Right of 'b
+type ('a, 'b) both = {left : 'a; right : 'b}

--- a/examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/Makefile
+++ b/examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/Makefile
@@ -1,0 +1,12 @@
+SRC:=polymorphic_variant_lib.mli polymorphic_variant_lib.ml polymorphic_variant_bin.ml
+
+all: build analyze
+
+build:
+	ocamlopt -w +37 -bin-annot ${SRC}
+
+analyze:
+	dead_code_analyzer --nothing -T all .
+
+clean:
+	rm -f *.cm* *.o a.out

--- a/examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_bin.ml
+++ b/examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_bin.ml
@@ -1,0 +1,7 @@
+(* polymorphic_variant_bin.ml *)
+let () =
+  let open Polymorphic_variant_lib in
+  let x = 0 in
+  let poly = poly_of_int x in
+  let f =  float_opt_of_poly poly in
+  assert (f = None)

--- a/examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_lib.ml
+++ b/examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_lib.ml
@@ -1,0 +1,8 @@
+(* polymorphic_variant_lib.ml *)
+type poly = [`Int of int | `Float of float]
+
+let poly_of_int x = `Int x
+
+let float_opt_of_poly = function
+  | `Float f -> Some f
+  | _ -> None

--- a/examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_lib.mli
+++ b/examples/docs/fields_and_constructors/code_constructs/polymorphic_variant/polymorphic_variant_lib.mli
@@ -1,0 +1,6 @@
+(* polymorphic_variant_lib.mli *)
+type poly = [`Int of int | `Float of float]
+
+val poly_of_int : int -> [> `Int of int]
+
+val float_opt_of_poly : poly -> float option


### PR DESCRIPTION
Fix https://github.com/LexiFi/dead_code_analyzer/issues/60

The new documentation provides some preliminary definitions to understand what the analyzer tracks and may report in the constructors/record fields section.
It also provides examples focusing on different simple code constructs (gadt, inline records, ...), and document known limitations.

The code of the examples explored in the .md files is also provided in its own files to ease user experimentation, and is included in the testsuite.