### PR TITLE
Add doc for optional arguments always/never used

### DIFF
--- a/check/classic/classic.exp
+++ b/check/classic/classic.exp
@@ -320,6 +320,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
+
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
 
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: ?x

--- a/check/classic/classic.exp
+++ b/check/classic/classic.exp
@@ -320,6 +320,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
+
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: ?x
 
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?always
@@ -467,6 +469,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
+
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: ?x
 
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?externally

--- a/check/classic/classic.exp
+++ b/check/classic/classic.exp
@@ -32,6 +32,9 @@
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:8: random_factory
 
+./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:2: max
+./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:3: min
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:3: internally_used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:38: internally_used_f
@@ -320,6 +323,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
+
 ./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
@@ -471,6 +476,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:2: ?min
+
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
 
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: ?x

--- a/check/classic/classic.exp
+++ b/check/classic/classic.exp
@@ -32,6 +32,8 @@
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:8: random_factory
 
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:9: add_index
+
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:2: max
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:3: min
 
@@ -324,6 +326,9 @@ Nothing else to report in this section
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
 ./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:3: ?max
+
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:2: ?index
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:6: ?index
 
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
 
@@ -638,6 +643,8 @@ Nothing else to report in this section
 
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:3: let x = ... in x (=> useless binding)
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:12: let x = ... in x (=> useless binding)
+
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:2: val f: ... -> (... -> ?_:_ -> ...) -> ...
 
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: let () = ... in ... (=> use sequence)
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: unit pattern unit_binding

--- a/check/classic/classic.exp
+++ b/check/classic/classic.exp
@@ -320,6 +320,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: ?x
+
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?always
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?internally
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:59: ?always
@@ -465,6 +467,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: ?x
+
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?externally
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?never
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:59: ?never

--- a/check/classic/classic.exp
+++ b/check/classic/classic.exp
@@ -327,6 +327,9 @@ Nothing else to report in this section
 
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
 
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.ml:9: ?max
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.mli:2: ?min
+
 ./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
@@ -481,6 +484,9 @@ Nothing else to report in this section
 ./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:2: ?min
 
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:2: ?min
+
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.ml:2: ?min
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.mli:3: ?max
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
 

--- a/check/classic/classic.exp
+++ b/check/classic/classic.exp
@@ -323,6 +323,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:3: ?max
+
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
 
 ./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
@@ -476,6 +478,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:2: ?min
+
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:2: ?min
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y

--- a/check/classic/classic.ref
+++ b/check/classic/classic.ref
@@ -37,6 +37,9 @@
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:8: random_factory
 
+./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:2: max
+./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:3: min
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:3: internally_used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:38: internally_used_f
@@ -325,6 +328,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
+
 ./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
@@ -476,6 +481,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:2: ?min
+
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
 
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: ?x
@@ -674,7 +681,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 567
-Success: 560
+Total: 571
+Success: 564
 Failed: 7
-Ratio: 98.7654320988%
+Ratio: 98.7740805604%

--- a/check/classic/classic.ref
+++ b/check/classic/classic.ref
@@ -328,6 +328,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:3: ?max
+
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
 
 ./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
@@ -481,6 +483,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:2: ?min
+
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:2: ?min
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
@@ -681,7 +685,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 571
-Success: 564
+Total: 573
+Success: 566
 Failed: 7
-Ratio: 98.7740805604%
+Ratio: 98.7783595113%

--- a/check/classic/classic.ref
+++ b/check/classic/classic.ref
@@ -325,6 +325,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
+
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: ?x
 
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?always
@@ -472,6 +474,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
+
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: ?x
 
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?externally
@@ -668,7 +672,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 564
-Success: 557
+Total: 566
+Success: 559
 Failed: 7
-Ratio: 98.7588652482%
+Ratio: 98.7632508834%

--- a/check/classic/classic.ref
+++ b/check/classic/classic.ref
@@ -37,6 +37,8 @@
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:8: random_factory
 
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:9: add_index
+
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:2: max
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:3: min
 
@@ -329,6 +331,9 @@ Nothing else to report in this section
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
 ./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:3: ?max
+
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:2: ?index
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:6: ?index
 
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
 
@@ -644,6 +649,8 @@ Nothing else to report in this section
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:3: let x = ... in x (=> useless binding)
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:12: let x = ... in x (=> useless binding)
 
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:2: val f: ... -> (... -> ?_:_ -> ...) -> ...
+
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: let () = ... in ... (=> use sequence)
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: unit pattern unit_binding
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:84: val f: ... -> (... -> ?_:_ -> ...) -> ...
@@ -691,7 +698,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 577
-Success: 570
+Total: 581
+Success: 574
 Failed: 7
-Ratio: 98.7868284229%
+Ratio: 98.7951807229%

--- a/check/classic/classic.ref
+++ b/check/classic/classic.ref
@@ -325,6 +325,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
+
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
 
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: ?x
@@ -672,7 +674,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 566
-Success: 559
+Total: 567
+Success: 560
 Failed: 7
-Ratio: 98.7632508834%
+Ratio: 98.7654320988%

--- a/check/classic/classic.ref
+++ b/check/classic/classic.ref
@@ -332,6 +332,9 @@ Nothing else to report in this section
 
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
 
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.ml:9: ?max
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.mli:2: ?min
+
 ./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
@@ -486,6 +489,9 @@ Nothing else to report in this section
 ./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:2: ?min
 
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:2: ?min
+
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.ml:2: ?min
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.mli:3: ?max
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
 
@@ -685,7 +691,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 573
-Success: 566
+Total: 577
+Success: 570
 Failed: 7
-Ratio: 98.7783595113%
+Ratio: 98.7868284229%

--- a/check/classic/classic.ref
+++ b/check/classic/classic.ref
@@ -325,6 +325,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: ?x
+
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?always
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?internally
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:59: ?always
@@ -470,6 +472,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: ?x
+
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?externally
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?never
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:59: ?never
@@ -664,7 +668,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 562
-Success: 555
+Total: 564
+Success: 557
 Failed: 7
-Ratio: 98.7544483986%
+Ratio: 98.7588652482%

--- a/check/internal/internal.exp
+++ b/check/internal/internal.exp
@@ -275,6 +275,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
+
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
 
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: ?x

--- a/check/internal/internal.exp
+++ b/check/internal/internal.exp
@@ -279,6 +279,9 @@ Nothing else to report in this section
 
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
 
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.ml:9: ?max
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.mli:2: ?min
+
 ./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
@@ -433,6 +436,9 @@ Nothing else to report in this section
 ./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:2: ?min
 
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:2: ?min
+
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.ml:2: ?min
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.mli:3: ?max
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
 

--- a/check/internal/internal.exp
+++ b/check/internal/internal.exp
@@ -275,6 +275,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
+
 ./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
@@ -426,6 +428,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:2: ?min
+
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
 
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: ?x

--- a/check/internal/internal.exp
+++ b/check/internal/internal.exp
@@ -22,6 +22,8 @@
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:8: random_factory
 
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:9: add_index
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:2: unused
 
@@ -276,6 +278,9 @@ Nothing else to report in this section
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
 ./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:3: ?max
+
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:2: ?index
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:6: ?index
 
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
 
@@ -590,6 +595,8 @@ Nothing else to report in this section
 
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:3: let x = ... in x (=> useless binding)
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:12: let x = ... in x (=> useless binding)
+
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:2: val f: ... -> (... -> ?_:_ -> ...) -> ...
 
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: let () = ... in ... (=> use sequence)
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: unit pattern unit_binding

--- a/check/internal/internal.exp
+++ b/check/internal/internal.exp
@@ -275,6 +275,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
+
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: ?x
 
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?always
@@ -422,6 +424,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
+
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: ?x
 
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?externally

--- a/check/internal/internal.exp
+++ b/check/internal/internal.exp
@@ -275,6 +275,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:3: ?max
+
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
 
 ./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
@@ -428,6 +430,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:2: ?min
+
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:2: ?min
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y

--- a/check/internal/internal.exp
+++ b/check/internal/internal.exp
@@ -275,6 +275,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: ?x
+
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?always
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?internally
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:59: ?always
@@ -420,6 +422,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: ?x
+
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?externally
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?never
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:59: ?never

--- a/check/internal/internal.ref
+++ b/check/internal/internal.ref
@@ -284,6 +284,9 @@ Nothing else to report in this section
 
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
 
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.ml:9: ?max
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.mli:2: ?min
+
 ./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
@@ -438,6 +441,9 @@ Nothing else to report in this section
 ./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:2: ?min
 
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:2: ?min
+
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.ml:2: ?min
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.mli:3: ?max
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
 
@@ -637,7 +643,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 529
-Success: 522
+Total: 533
+Success: 526
 Failed: 7
-Ratio: 98.6767485822%
+Ratio: 98.6866791745%

--- a/check/internal/internal.ref
+++ b/check/internal/internal.ref
@@ -280,6 +280,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: ?x
+
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?always
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?internally
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:59: ?always
@@ -425,6 +427,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: ?x
+
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?externally
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?never
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:59: ?never
@@ -619,7 +623,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 520
-Success: 513
+Total: 522
+Success: 515
 Failed: 7
-Ratio: 98.6538461538%
+Ratio: 98.6590038314%

--- a/check/internal/internal.ref
+++ b/check/internal/internal.ref
@@ -280,6 +280,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
+
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
 
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: ?x
@@ -627,7 +629,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 524
-Success: 517
+Total: 525
+Success: 518
 Failed: 7
-Ratio: 98.6641221374%
+Ratio: 98.6666666667%

--- a/check/internal/internal.ref
+++ b/check/internal/internal.ref
@@ -280,6 +280,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
+
 ./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
@@ -431,6 +433,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:2: ?min
+
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
 
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: ?x
@@ -629,7 +633,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 525
-Success: 518
+Total: 527
+Success: 520
 Failed: 7
-Ratio: 98.6666666667%
+Ratio: 98.6717267552%

--- a/check/internal/internal.ref
+++ b/check/internal/internal.ref
@@ -280,6 +280,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
+
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: ?x
 
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?always
@@ -427,6 +429,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
+
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: ?x
 
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?externally
@@ -623,7 +627,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 522
-Success: 515
+Total: 524
+Success: 517
 Failed: 7
-Ratio: 98.6590038314%
+Ratio: 98.6641221374%

--- a/check/internal/internal.ref
+++ b/check/internal/internal.ref
@@ -280,6 +280,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:3: ?max
+
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
 
 ./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
@@ -433,6 +435,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:2: ?min
+
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:2: ?min
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
@@ -633,7 +637,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 527
-Success: 520
+Total: 529
+Success: 522
 Failed: 7
-Ratio: 98.6717267552%
+Ratio: 98.6767485822%

--- a/check/internal/internal.ref
+++ b/check/internal/internal.ref
@@ -27,6 +27,8 @@
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:8: random_factory
 
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:9: add_index
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:2: unused
 
@@ -281,6 +283,9 @@ Nothing else to report in this section
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
 ./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:3: ?max
+
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:2: ?index
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:6: ?index
 
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
 
@@ -596,6 +601,8 @@ Nothing else to report in this section
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:3: let x = ... in x (=> useless binding)
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:12: let x = ... in x (=> useless binding)
 
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:2: val f: ... -> (... -> ?_:_ -> ...) -> ...
+
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: let () = ... in ... (=> use sequence)
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: unit pattern unit_binding
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:84: val f: ... -> (... -> ?_:_ -> ...) -> ...
@@ -643,7 +650,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 533
-Success: 526
+Total: 537
+Success: 530
 Failed: 7
-Ratio: 98.6866791745%
+Ratio: 98.696461825%

--- a/check/threshold-1/threshold-1.exp
+++ b/check/threshold-1/threshold-1.exp
@@ -169,6 +169,8 @@
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:8: alias
 
+./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: g
+
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_lib.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_no_intf.mli:1: mark_used
@@ -716,6 +718,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: ?x
+
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?always
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?internally
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:59: ?always
@@ -861,6 +865,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: ?x
+
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?externally
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?never
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:59: ?never

--- a/check/threshold-1/threshold-1.exp
+++ b/check/threshold-1/threshold-1.exp
@@ -169,6 +169,8 @@
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:8: alias
 
+./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: sum
+
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: g
 
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
@@ -718,6 +720,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
+
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: ?x
 
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?always
@@ -865,6 +869,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
+
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: ?x
 
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?externally

--- a/check/threshold-1/threshold-1.exp
+++ b/check/threshold-1/threshold-1.exp
@@ -169,6 +169,9 @@
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:8: alias
 
+./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:2: max
+./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:3: min
+
 ./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: sum
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: sum
@@ -722,6 +725,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
+
 ./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
@@ -873,6 +878,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:2: ?min
+
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
 
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: ?x

--- a/check/threshold-1/threshold-1.exp
+++ b/check/threshold-1/threshold-1.exp
@@ -732,6 +732,9 @@ Nothing else to report in this section
 
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
 
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.ml:9: ?max
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.mli:2: ?min
+
 ./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
@@ -886,6 +889,9 @@ Nothing else to report in this section
 ./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:2: ?min
 
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:2: ?min
+
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.ml:2: ?min
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.mli:3: ?max
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
 

--- a/check/threshold-1/threshold-1.exp
+++ b/check/threshold-1/threshold-1.exp
@@ -169,6 +169,9 @@
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:8: alias
 
+./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:2: max
+./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:3: min
+
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:2: max
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:3: min
 
@@ -725,6 +728,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:3: ?max
+
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
 
 ./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
@@ -878,6 +883,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:2: ?min
+
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:2: ?min
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y

--- a/check/threshold-1/threshold-1.exp
+++ b/check/threshold-1/threshold-1.exp
@@ -22,6 +22,8 @@
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:8: random_factory
 
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:9: add_index
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:2: unused
 
@@ -171,6 +173,8 @@
 
 ./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:2: max
 ./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:3: min
+
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:2: map_with_index
 
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:2: max
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:3: min
@@ -730,6 +734,9 @@ Nothing else to report in this section
 =============================
 ./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:3: ?max
 
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:2: ?index
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:6: ?index
+
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
 
 ./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.ml:9: ?max
@@ -1043,6 +1050,8 @@ Nothing else to report in this section
 
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:3: let x = ... in x (=> useless binding)
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:12: let x = ... in x (=> useless binding)
+
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:2: val f: ... -> (... -> ?_:_ -> ...) -> ...
 
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: let () = ... in ... (=> use sequence)
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: unit pattern unit_binding

--- a/check/threshold-1/threshold-1.exp
+++ b/check/threshold-1/threshold-1.exp
@@ -169,6 +169,8 @@
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:8: alias
 
+./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: sum
+
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: sum
 
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: g
@@ -720,6 +722,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
+
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
 
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: ?x

--- a/check/threshold-1/threshold-1.ref
+++ b/check/threshold-1/threshold-1.ref
@@ -174,6 +174,9 @@
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:8: alias
 
+./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:2: max
+./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:3: min
+
 ./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: sum
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: sum
@@ -726,6 +729,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
+
 ./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
@@ -877,6 +882,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:2: ?min
+
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
 
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: ?x
@@ -1075,7 +1082,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 899
-Success: 891
+Total: 903
+Success: 895
 Failed: 8
-Ratio: 99.1101223582%
+Ratio: 99.1140642303%

--- a/check/threshold-1/threshold-1.ref
+++ b/check/threshold-1/threshold-1.ref
@@ -174,6 +174,8 @@
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:8: alias
 
+./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: sum
+
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: sum
 
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: g
@@ -724,6 +726,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
+
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
 
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: ?x
@@ -1071,7 +1075,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 897
-Success: 889
+Total: 899
+Success: 891
 Failed: 8
-Ratio: 99.1081382386%
+Ratio: 99.1101223582%

--- a/check/threshold-1/threshold-1.ref
+++ b/check/threshold-1/threshold-1.ref
@@ -736,6 +736,9 @@ Nothing else to report in this section
 
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
 
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.ml:9: ?max
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.mli:2: ?min
+
 ./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
@@ -890,6 +893,9 @@ Nothing else to report in this section
 ./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:2: ?min
 
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:2: ?min
+
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.ml:2: ?min
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.mli:3: ?max
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
 
@@ -1089,7 +1095,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 907
-Success: 899
+Total: 911
+Success: 903
 Failed: 8
-Ratio: 99.1179713341%
+Ratio: 99.1218441273%

--- a/check/threshold-1/threshold-1.ref
+++ b/check/threshold-1/threshold-1.ref
@@ -174,6 +174,8 @@
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:8: alias
 
+./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: g
+
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_lib.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_no_intf.mli:1: mark_used
@@ -720,6 +722,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: ?x
+
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?always
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?internally
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:59: ?always
@@ -865,6 +869,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: ?x
+
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?externally
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?never
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:59: ?never
@@ -1059,7 +1065,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 891
-Success: 883
+Total: 894
+Success: 886
 Failed: 8
-Ratio: 99.1021324355%
+Ratio: 99.1051454139%

--- a/check/threshold-1/threshold-1.ref
+++ b/check/threshold-1/threshold-1.ref
@@ -174,6 +174,9 @@
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:8: alias
 
+./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:2: max
+./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:3: min
+
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:2: max
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:3: min
 
@@ -729,6 +732,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:3: ?max
+
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
 
 ./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
@@ -882,6 +887,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:2: ?min
+
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:2: ?min
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
@@ -1082,7 +1089,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 903
-Success: 895
+Total: 907
+Success: 899
 Failed: 8
-Ratio: 99.1140642303%
+Ratio: 99.1179713341%

--- a/check/threshold-1/threshold-1.ref
+++ b/check/threshold-1/threshold-1.ref
@@ -27,6 +27,8 @@
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:8: random_factory
 
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:9: add_index
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:2: unused
 
@@ -176,6 +178,8 @@
 
 ./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:2: max
 ./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:3: min
+
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:2: map_with_index
 
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:2: max
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:3: min
@@ -734,6 +738,9 @@ Nothing else to report in this section
 =============================
 ./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:3: ?max
 
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:2: ?index
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:6: ?index
+
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
 
 ./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.ml:9: ?max
@@ -1048,6 +1055,8 @@ Nothing else to report in this section
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:3: let x = ... in x (=> useless binding)
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:12: let x = ... in x (=> useless binding)
 
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:2: val f: ... -> (... -> ?_:_ -> ...) -> ...
+
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: let () = ... in ... (=> use sequence)
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: unit pattern unit_binding
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:84: val f: ... -> (... -> ?_:_ -> ...) -> ...
@@ -1095,7 +1104,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 911
-Success: 903
+Total: 916
+Success: 908
 Failed: 8
-Ratio: 99.1218441273%
+Ratio: 99.1266375546%

--- a/check/threshold-1/threshold-1.ref
+++ b/check/threshold-1/threshold-1.ref
@@ -174,6 +174,8 @@
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:8: alias
 
+./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: sum
+
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: g
 
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
@@ -722,6 +724,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
+
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: ?x
 
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?always
@@ -869,6 +873,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
+
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: ?x
 
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?externally
@@ -1065,7 +1071,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 894
-Success: 886
+Total: 897
+Success: 889
 Failed: 8
-Ratio: 99.1051454139%
+Ratio: 99.1081382386%

--- a/check/threshold-3-0.5/threshold-3-0.5.exp
+++ b/check/threshold-3-0.5/threshold-3-0.5.exp
@@ -169,6 +169,9 @@
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:8: alias
 
+./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:2: max
+./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:3: min
+
 ./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: sum
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: sum
@@ -944,6 +947,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
+
 ./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
@@ -1193,6 +1198,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:2: ?min
+
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
 
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: ?x

--- a/check/threshold-3-0.5/threshold-3-0.5.exp
+++ b/check/threshold-3-0.5/threshold-3-0.5.exp
@@ -169,6 +169,9 @@
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:8: alias
 
+./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:2: max
+./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:3: min
+
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:2: max
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:3: min
 
@@ -947,6 +950,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:3: ?max
+
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
 
 ./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
@@ -1198,6 +1203,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:2: ?min
+
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:2: ?min
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y

--- a/check/threshold-3-0.5/threshold-3-0.5.exp
+++ b/check/threshold-3-0.5/threshold-3-0.5.exp
@@ -169,6 +169,8 @@
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:8: alias
 
+./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: sum
+
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: sum
 
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: g
@@ -942,6 +944,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
+
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
 
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: ?x

--- a/check/threshold-3-0.5/threshold-3-0.5.exp
+++ b/check/threshold-3-0.5/threshold-3-0.5.exp
@@ -22,6 +22,8 @@
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:8: random_factory
 
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:9: add_index
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:2: unused
 
@@ -171,6 +173,8 @@
 
 ./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:2: max
 ./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:3: min
+
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:2: map_with_index
 
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:2: max
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:3: min
@@ -955,6 +959,9 @@ Nothing else to report in this section
 =============================
 ./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:3: ?max
 
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:2: ?index
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:6: ?index
+
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
 
 ./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.ml:9: ?max
@@ -1447,6 +1454,8 @@ Nothing else to report in this section
 
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:3: let x = ... in x (=> useless binding)
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:12: let x = ... in x (=> useless binding)
+
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:2: val f: ... -> (... -> ?_:_ -> ...) -> ...
 
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: let () = ... in ... (=> use sequence)
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: unit pattern unit_binding

--- a/check/threshold-3-0.5/threshold-3-0.5.exp
+++ b/check/threshold-3-0.5/threshold-3-0.5.exp
@@ -169,6 +169,8 @@
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:8: alias
 
+./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: g
+
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_lib.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_no_intf.mli:1: mark_used
@@ -377,6 +379,8 @@
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:4: world
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original
+
+./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: f
 
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:2: used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:31: exported_f
@@ -936,6 +940,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: ?x
+
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?always
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?internally
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:59: ?always
@@ -1179,6 +1185,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: ?x
+
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?externally
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?never
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:59: ?never

--- a/check/threshold-3-0.5/threshold-3-0.5.exp
+++ b/check/threshold-3-0.5/threshold-3-0.5.exp
@@ -169,6 +169,8 @@
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:8: alias
 
+./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: sum
+
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: g
 
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
@@ -940,6 +942,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
+
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: ?x
 
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?always
@@ -1185,6 +1189,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
+
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: ?x
 
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?externally

--- a/check/threshold-3-0.5/threshold-3-0.5.exp
+++ b/check/threshold-3-0.5/threshold-3-0.5.exp
@@ -390,6 +390,9 @@
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original
 
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.mli:2: max
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.mli:3: min
+
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: f
 
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:2: used
@@ -954,6 +957,9 @@ Nothing else to report in this section
 
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
 
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.ml:9: ?max
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.mli:2: ?min
+
 ./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
@@ -1206,6 +1212,9 @@ Nothing else to report in this section
 ./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:2: ?min
 
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:2: ?min
+
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.ml:2: ?min
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.mli:3: ?max
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
 

--- a/check/threshold-3-0.5/threshold-3-0.5.ref
+++ b/check/threshold-3-0.5/threshold-3-0.5.ref
@@ -174,6 +174,8 @@
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:8: alias
 
+./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: sum
+
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: sum
 
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: g
@@ -946,6 +948,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
+
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
 
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: ?x
@@ -1472,7 +1476,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 1215
-Success: 1207
+Total: 1217
+Success: 1209
 Failed: 8
-Ratio: 99.341563786%
+Ratio: 99.3426458505%

--- a/check/threshold-3-0.5/threshold-3-0.5.ref
+++ b/check/threshold-3-0.5/threshold-3-0.5.ref
@@ -395,6 +395,9 @@
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original
 
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.mli:2: max
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.mli:3: min
+
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: f
 
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:2: used
@@ -958,6 +961,9 @@ Nothing else to report in this section
 
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
 
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.ml:9: ?max
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.mli:2: ?min
+
 ./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
@@ -1210,6 +1216,9 @@ Nothing else to report in this section
 ./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:2: ?min
 
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:2: ?min
+
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.ml:2: ?min
+./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.mli:3: ?max
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
 
@@ -1490,7 +1499,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 1225
-Success: 1217
+Total: 1231
+Success: 1223
 Failed: 8
-Ratio: 99.3469387755%
+Ratio: 99.3501218522%

--- a/check/threshold-3-0.5/threshold-3-0.5.ref
+++ b/check/threshold-3-0.5/threshold-3-0.5.ref
@@ -27,6 +27,8 @@
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:2: factory_with_intermediate_binding
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:8: random_factory
 
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:9: add_index
+
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:2: unused
 
@@ -176,6 +178,8 @@
 
 ./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:2: max
 ./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:3: min
+
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:2: map_with_index
 
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:2: max
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:3: min
@@ -959,6 +963,9 @@ Nothing else to report in this section
 =============================
 ./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:3: ?max
 
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:2: ?index
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:6: ?index
+
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
 
 ./examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.ml:9: ?max
@@ -1452,6 +1459,8 @@ Nothing else to report in this section
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:3: let x = ... in x (=> useless binding)
 ./examples/docs/methods/limitations/factory_fun_indir/factory_fun_indir.ml:12: let x = ... in x (=> useless binding)
 
+./examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml:2: val f: ... -> (... -> ?_:_ -> ...) -> ...
+
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: let () = ... in ... (=> use sequence)
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:83: unit pattern unit_binding
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:84: val f: ... -> (... -> ?_:_ -> ...) -> ...
@@ -1499,7 +1508,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 1231
-Success: 1223
+Total: 1236
+Success: 1228
 Failed: 8
-Ratio: 99.3501218522%
+Ratio: 99.3527508091%

--- a/check/threshold-3-0.5/threshold-3-0.5.ref
+++ b/check/threshold-3-0.5/threshold-3-0.5.ref
@@ -174,6 +174,8 @@
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:8: alias
 
+./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: sum
+
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: g
 
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
@@ -944,6 +946,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
+
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: ?x
 
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?always
@@ -1189,6 +1193,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
+
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: ?x
 
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?externally
@@ -1466,7 +1472,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 1212
-Success: 1204
+Total: 1215
+Success: 1207
 Failed: 8
-Ratio: 99.3399339934%
+Ratio: 99.341563786%

--- a/check/threshold-3-0.5/threshold-3-0.5.ref
+++ b/check/threshold-3-0.5/threshold-3-0.5.ref
@@ -174,6 +174,8 @@
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:8: alias
 
+./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: g
+
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_lib.mli:1: mark_used
 ./examples/using_dune/bin/use_preprocessed_lib/use_preprocessed_no_intf.mli:1: mark_used
@@ -382,6 +384,8 @@
 ./examples/docs/exported_values/hello_world/hello_world_without_intf.ml:4: world
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:2: original
+
+./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: f
 
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:2: used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:31: exported_f
@@ -940,6 +944,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: ?x
+
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?always
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?internally
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:59: ?always
@@ -1183,6 +1189,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: ?x
+
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?externally
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:53: ?never
 ./examples/using_dune/preprocessed_lib/preprocessed.ml:59: ?never
@@ -1458,7 +1466,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 1208
-Success: 1200
+Total: 1212
+Success: 1204
 Failed: 8
-Ratio: 99.3377483444%
+Ratio: 99.3399339934%

--- a/check/threshold-3-0.5/threshold-3-0.5.ref
+++ b/check/threshold-3-0.5/threshold-3-0.5.ref
@@ -174,6 +174,9 @@
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:8: alias
 
+./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:2: max
+./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:3: min
+
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:2: max
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:3: min
 
@@ -951,6 +954,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:3: ?max
+
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
 
 ./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
@@ -1202,6 +1207,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli:2: ?min
+
 ./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:2: ?min
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
@@ -1483,7 +1490,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 1221
-Success: 1213
+Total: 1225
+Success: 1217
 Failed: 8
-Ratio: 99.3447993448%
+Ratio: 99.3469387755%

--- a/check/threshold-3-0.5/threshold-3-0.5.ref
+++ b/check/threshold-3-0.5/threshold-3-0.5.ref
@@ -174,6 +174,9 @@
 
 ./examples/docs/methods/limitations/alias/alias_lib.mli:8: alias
 
+./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:2: max
+./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli:3: min
+
 ./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: sum
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: sum
@@ -948,6 +951,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: ALWAYS:
 =============================
+./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:9: ?max
+
 ./examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
 
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
@@ -1197,6 +1202,8 @@ Nothing else to report in this section
 
 .> OPTIONAL ARGUMENTS: NEVER:
 ============================
+./examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml:2: ?min
+
 ./examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
 
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: ?x
@@ -1476,7 +1483,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 1217
-Success: 1209
+Total: 1221
+Success: 1213
 Failed: 8
-Ratio: 99.3426458505%
+Ratio: 99.3447993448%

--- a/docs/USER_DOC.md
+++ b/docs/USER_DOC.md
@@ -56,6 +56,7 @@ This documentation is split accross different topics:
 - [Exported Values](exported_values/EXPORTED_VALUES.md) describes the semantics and usage of the "unused exported values" report section, and provides examples.
 - [Methods](methods/METHODS.md) describes the semantics and usage of the "unused methods" report section, and provides examples.
 - [Constructors/Record fields](fields_and_constructors/FIELDS_AND_CONSTRUCTORS.md) describes the semantics and usage of the "unused constructors/record fields" report section, and provides examples.
+- [Optional arguments](optional_arguments/OPTIONAL_ARGUMENTS.md) describes the semantics and usage of the optional arguments always/never used report sections, and provides examples.
 
 
 ## Footnotes

--- a/docs/optional_arguments/OPTIONAL_ARGUMENTS.md
+++ b/docs/optional_arguments/OPTIONAL_ARGUMENTS.md
@@ -222,6 +222,7 @@ argument as never used if its declaring function is never fully applied.
     - [Partial application](./code_constructs/PARTIAL_APP.md)
     - [Internal application](./code_constructs/INTERNAL_APPLICATION.md)
     - [External application](./code_constructs/EXTERNAL_APPLICATION.md)
+    - [Internal and external application](./code_constructs/INTEXT_APPLICATION.md)
 
 # Limitations
 

--- a/docs/optional_arguments/OPTIONAL_ARGUMENTS.md
+++ b/docs/optional_arguments/OPTIONAL_ARGUMENTS.md
@@ -221,6 +221,7 @@ argument as never used if its declaring function is never fully applied.
     - [Total application](./code_constructs/TOTAL_APP.md)
     - [Partial application](./code_constructs/PARTIAL_APP.md)
     - [Internal application](./code_constructs/INTERNAL_APPLICATION.md)
+    - [External application](./code_constructs/EXTERNAL_APPLICATION.md)
 
 # Limitations
 

--- a/docs/optional_arguments/OPTIONAL_ARGUMENTS.md
+++ b/docs/optional_arguments/OPTIONAL_ARGUMENTS.md
@@ -1,0 +1,306 @@
+# Table of contents
+
++ [Optional arguments](#optional-arguments)
+    + [Definitions](#definitions)
+    + [Compiler warnings](#compiler-warnings)
+        + [Warning 16: unerasable-optional-argument](#warning-26-unerasable-optional-argument)
+    + [Usage](#usage)
+        +[Optional arguments always used](#optional-arguments-always-used)
+        +[Optional arguments never used](#optional-arguments-never-used)
++ [Limitations](#limitations)
+    + [Relaying](#relaying)
+
+# Optional arguments
+
+## Definitions
+
+An **optional parameter** is a labeled parameter defined by prefixing the label
+with `?`.
+
+An **optional argument** is the value given (explicitly or implicitly) to an
+optional parameter. Depending on the value, an optional argument is either used
+or discarded.
+
+A **use** is either :
+- Explicitly providing a value.
+  E.g.
+  ```OCaml
+  let x_or_default ?x default =
+    match x with
+    | Some x -> x
+    | None -> default
+
+  let _ = x_or_default ~x:true false
+  let _ = x_or_default ?x:(Some true) false
+  ```
+  The optional argument `?x` is provided `true` explicitly in two different
+  ways: `~x:true` and `?x:(Some true)`.
+- Relaying an optional argument.
+  E.g.
+  ```OCaml
+  let x_or_default ?x default =
+    match x with
+    | Some x -> x
+    | None -> default
+
+  let add_x_or_zero ?x n =
+    let x = x_or_default ?x 0 in
+    n + x
+  ```
+  The optional argument `?x` of `x_or_default` is used in `add_x_or_zero` by
+  transferring the latter function's argument's value to the former.
+- A requirement for that argument to exist.
+  E.g.
+  ```OCaml
+  let list_map ?f l =
+    match f with
+    | None -> l
+    | Some f -> List.map f l
+
+  let super_map ~map ?f l = map ?f l
+
+  let _ = super_map ~map:list_map []
+  ```
+  The optional argument `?f` of `list_map` is used by requirement in
+  `super_map ~map:list_map []`, because the type of the `~map` parameter
+  of `super_map` is `?f:'a -> 'b -> 'c`. If `list_map` did not expect an
+  optional argument `?f`, then the compilation would fail with an error like :
+  ```
+  File "requirement.ml", line 8, characters 23-31:
+  8 | let _ = super_map ~map:list_map []
+                             ^^^^^^^^
+  Error: This expression has type ('a -> 'a) option -> 'a list -> 'a list
+         but an expression was expected of type ?f:'b -> 'c -> 'd
+  ```
+
+> [!WARNING]
+> The use by relay may lead to more complex resolutions than desired. Thus, the
+> definition of use may change in the future and affect the reports.
+> See the [Relaying | Limitations](#relaying) for more information
+
+A **discard** is either :
+- Explicitly passing `None`.
+  E.g.
+  ```OCaml
+  let x_or_default ?x default =
+    match x with
+    | Some x -> x
+    | None -> default
+
+  let _ = x_or_default ?x:None false
+  ```
+  The optional argument `?x` is discarded by `?x:None`.
+- Not providing any value while totally applying the function :
+  E.g.
+  ```OCaml
+  let x_or_default ?x default =
+    match x with
+    | Some x -> x
+    | None -> default
+
+  let _ = x_or_default false
+  ```
+  The optional argument `?x` is discarded in the call `x_or_default false`
+  because the function is totally applied and the argument is not provided any
+  value.
+
+> [!NOTE]
+> Setting default values for optional parameters does not change the definitions
+> of use and discard for the optional arguments.
+
+## Compiler warnings
+
+The analyzer reports always and never used optional arguments. The compiler does
+not have such warnings.
+
+> [!TIP]
+> To obtain a list of available compiler warnings, use
+> `ocamlopt -warn-help`
+
+Although the compiler does not have warnings related to always/never used
+optional arguments, it has a relevant warning : the 16.
+
+### Warning 16: unerasable-optional-argument
+
+This warning is enabled by default.
+It can be disabled by passing the `-w -16` to the compiler.
+
+Description:
+```
+16 [unerasable-optional-argument] Unerasable optional argument.
+```
+
+Example:
+```OCaml
+(* warning16.ml *)
+let f ?x = ()
+```
+```
+$ ocamlopt warning16.ml
+File "warning16.ml", line 2, characters 7-8:
+1 | let f ?x = ()
+           ^
+Warning 16 [unerasable-optional-argument]: this optional argument cannot be erased.
+```
+
+## Usage
+
+Optional arguments always (resp. never) used are not reported by default.
+Their reports can be activated by using the `--all` or `-Oa all` (resp.
+`-On all`) command line arguments.
+They can be deactivated by using the `--nothing` or `-Oa nothing` (resp.
+`-On nothing`) command line arguments.
+For more details about the command line arguments see [the more general Usage
+documentation](../USAGE.md).
+
+## Optional arguments always used
+
+The report section looks like:
+```
+.> OPTIONAL ARGUMENTS: ALWAYS:
+=============================
+filepath:line: ?arg
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+```
+The report line format is `filepath:line: ?arg` with `filepath` the absolute
+path to the file (`.mli` or `.ml`) where `?arg` is declared, `line` the line
+index in `filepath` at which the function that declares `?arg` is declared,
+and `?arg` the name of the optional argument.
+There can be any number of such lines.
+
+The expected resolution for an optional argument always used is to transform it
+into a non-optional labeled argument.
+
+> [!CAUTION]
+> The analyzer tracks sperately optional arguments declared in `.ml` and in
+> `.mli` files. This implies that it is possible that an optional argument is
+> reported always used inside its compilation but not outside (and vice-versa).
+> The examples should help understand the implication on the resolutions.
+
+> [!IMPORTANT]
+> Changing an optional argument into a mandatory one may trigger compilation
+> errors. In particular when the argument was used with the `?x` syntax.
+
+## Optional arguments never used
+
+The report section looks like:
+```
+.> OPTIONAL ARGUMENTS: NEVER:
+============================
+filepath:line: ?arg
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+```
+The report line format is the same as for optional arguments always used.
+
+The expected resolution for an optional argument never used is to remove it from
+the function's parameters.
+
+> [!CAUTION]
+> The analyzer tracks sperately optional arguments declared in `.ml` and in
+> `.mli` files. This implies that it is possible that an optional argument is
+> reported never used inside its compilation but not outside (and vice-versa).
+> The examples should help understand the implication on the resolutions.
+
+In order to provide actionable reports, the analyzer does not report an optional
+argument as never used if its declaring function is never fully applied.
+
+> [!IMPORTANT]
+> Removing an optional argument may trigger compilation errors.
+> In particular when the argument was explicitly discarded with the
+> `?x:None` syntax.
+
+# Limitations
+
+## Relaying
+
+Following the current definition of use, relaying an optional argument to
+a callee counts as a use for the callee's. This may lead to optional arguments
+reported as always used although they are only used by relay. Because the
+analyzer's tracking of use is intransitive, some complex may arise with the
+caller's optional argument not being always used (or even never used), which
+would lead to complex resolutions, losing the benefit of using the analyzer in
+to clean up the code in the first place.
+
+A future improvement could be to ignore optional arguments if they are used by
+relay, in order to focus the reports on more easily actionable results.
+A more complex but more precise improvement would be to introduce transitivety
+in the optional arguments analysis, to identify when a use by relay is actually
+always a use, never a use or sometimes a use. The latter case would then remove
+the optional argument relayed to from the reports.
+
+### Example
+
+The reference files for this example are in the
+[relaying](../../examples/docs/optional_arguments/limitations/relaying) directory.
+
+The reference takes place in `/tmp/docs/optional_arguments/limitations`, which
+is a copy of the [limitations](../../examples/docs/optional_arguments/limitations)
+directory. Reported locations may differ depending on the location of the source
+files.
+
+The compilation command is :
+```
+make -C relaying build
+```
+
+The analysis command is :
+```
+make -C relaying analyze
+```
+
+The compile + analyze command is :
+```
+make -C relaying
+```
+
+Code:
+```OCaml
+(* relaying_bin.ml *)
+let f ?x () = ignore x
+
+let g ?x () = f ?x ()
+
+let () =
+  f ~x:42 ();
+  g ()
+```
+
+Compile and analyze:
+```
+$ make -C relaying
+make: Entering directory '/tmp/docs/optional_arguments/limitations/relaying'
+ocamlopt -bin-annot relaying_bin.ml
+dead_code_analyzer --nothing -Oa all -On all .
+Scanning files...
+ [DONE]
+
+.> OPTIONAL ARGUMENTS: ALWAYS:
+=============================
+/tmp/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: ?x
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+.> OPTIONAL ARGUMENTS: NEVER:
+============================
+/tmp/docs/optional_arguments/limitations/relaying/relaying_bin.ml:4: ?x
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/optional_arguments/limitations/relaying'
+```
+The analyzer reports argument `?x` of `f` as always used but `?x` of `g` as
+never used.
+Looking at the code, `f`'s `?x` is used by providing an explicit value in
+`~x:42` and by relay in the definition of `g`. It is never discarded.
+
+If we removed `g`'s `?x` because it is never used, then `f`'s `?x`
+would be discarded in `g` and not be always used anymore. This demonstrates the
+ambiguity of the always used report in the presence of relaying.

--- a/docs/optional_arguments/OPTIONAL_ARGUMENTS.md
+++ b/docs/optional_arguments/OPTIONAL_ARGUMENTS.md
@@ -220,6 +220,7 @@ argument as never used if its declaring function is never fully applied.
   examples dedicated to specific code constructs :
     - [Total application](./code_constructs/TOTAL_APP.md)
     - [Partial application](./code_constructs/PARTIAL_APP.md)
+    - [Internal application](./code_constructs/INTERNAL_APPLICATION.md)
 
 # Limitations
 

--- a/docs/optional_arguments/OPTIONAL_ARGUMENTS.md
+++ b/docs/optional_arguments/OPTIONAL_ARGUMENTS.md
@@ -219,6 +219,7 @@ argument as never used if its declaring function is never fully applied.
 - The [code constructs](./code_constructs) directory contains a collection of
   examples dedicated to specific code constructs :
     - [Total application](./code_constructs/TOTAL_APP.md)
+    - [Partial application](./code_constructs/PARTIAL_APP.md)
 
 # Limitations
 

--- a/docs/optional_arguments/OPTIONAL_ARGUMENTS.md
+++ b/docs/optional_arguments/OPTIONAL_ARGUMENTS.md
@@ -223,6 +223,7 @@ argument as never used if its declaring function is never fully applied.
     - [Internal application](./code_constructs/INTERNAL_APPLICATION.md)
     - [External application](./code_constructs/EXTERNAL_APPLICATION.md)
     - [Internal and external application](./code_constructs/INTEXT_APPLICATION.md)
+    - [Higher-order function](./code_constructs/HIGHER_ORDER_FUNCTION.md)
 
 # Limitations
 

--- a/docs/optional_arguments/OPTIONAL_ARGUMENTS.md
+++ b/docs/optional_arguments/OPTIONAL_ARGUMENTS.md
@@ -7,6 +7,7 @@
     + [Usage](#usage)
         +[Optional arguments always used](#optional-arguments-always-used)
         +[Optional arguments never used](#optional-arguments-never-used)
++ [Examples](#examples)
 + [Limitations](#limitations)
     + [Relaying](#relaying)
 
@@ -212,6 +213,12 @@ argument as never used if its declaring function is never fully applied.
 > Removing an optional argument may trigger compilation errors.
 > In particular when the argument was explicitly discarded with the
 > `?x:None` syntax.
+
+# Examples
+
+- The [code constructs](./code_constructs) directory contains a collection of
+  examples dedicated to specific code constructs :
+    - [Total application](./code_constructs/TOTAL_APP.md)
 
 # Limitations
 

--- a/docs/optional_arguments/OPTIONAL_ARGUMENTS.md
+++ b/docs/optional_arguments/OPTIONAL_ARGUMENTS.md
@@ -15,7 +15,7 @@
 
 ## Definitions
 
-An **optional parameter** is a labeled parameter defined by prefixing the label
+An **optional parameter** is a labelled parameter defined by prefixing the label
 with `?`.
 
 An **optional argument** is the value given (explicitly or implicitly) to an
@@ -172,12 +172,13 @@ and `?arg` the name of the optional argument.
 There can be any number of such lines.
 
 The expected resolution for an optional argument always used is to transform it
-into a non-optional labeled argument.
+into a non-optional labelled argument.
 
 > [!CAUTION]
-> The analyzer tracks sperately optional arguments declared in `.ml` and in
-> `.mli` files. This implies that it is possible that an optional argument is
-> reported always used inside its compilation but not outside (and vice-versa).
+> The analyzer tracks separately optional arguments declared in a module's
+> structure and in a module's explicit signature. This implies that it is
+> possible for an optional argument to be reported as always used inside its
+> module but not outside (and vice-versa).
 > The examples should help understand the implication on the resolutions.
 
 > [!IMPORTANT]
@@ -201,9 +202,10 @@ The expected resolution for an optional argument never used is to remove it from
 the function's parameters.
 
 > [!CAUTION]
-> The analyzer tracks sperately optional arguments declared in `.ml` and in
-> `.mli` files. This implies that it is possible that an optional argument is
-> reported never used inside its compilation but not outside (and vice-versa).
+> The analyzer tracks separately optional arguments declared in a module's
+> structure and in a module's explicit signature. This implies that it is
+> possible for an optional argument to be reported as never used inside its
+> module but not outside (and vice-versa).
 > The examples should help understand the implication on the resolutions.
 
 In order to provide actionable reports, the analyzer does not report an optional
@@ -232,9 +234,9 @@ argument as never used if its declaring function is never fully applied.
 Following the current definition of use, relaying an optional argument to
 a callee counts as a use for the callee's. This may lead to optional arguments
 reported as always used although they are only used by relay. Because the
-analyzer's tracking of use is intransitive, some complex may arise with the
+analyzer's tracking of use is intransitive, some complex cases may arise with the
 caller's optional argument not being always used (or even never used), which
-would lead to complex resolutions, losing the benefit of using the analyzer in
+would lead to complex resolutions, losing the benefit of using the analyzer
 to clean up the code in the first place.
 
 A future improvement could be to ignore optional arguments if they are used by

--- a/docs/optional_arguments/code_constructs/EXTERNAL_APPLICATION.md
+++ b/docs/optional_arguments/code_constructs/EXTERNAL_APPLICATION.md
@@ -57,7 +57,7 @@ let () =
 Before looking at the analysis results, let's look at the code.
 
 There are 2 functions defined and exported by `External_app_lib`: `max` and
-`min. They both have an optional argument, and both functions are used
+`min`. They both have an optional argument, and both functions are used
 externally. Neither is used internally.
 Optional argument `?min` of `max` is never used. Optional argument `?max` of
 `min` is always used.
@@ -124,7 +124,7 @@ let () =
 ```
 
 We removed `?min` from function `max` and simplified its body.
-We transformed `?max` into a mandatory labeled argument `~max` in function `min`.
+We transformed `?max` into a mandatory labelled argument `~max` in function `min`.
 
 The signatures of the functions in the `.mli` have been changed accordingly.
 

--- a/docs/optional_arguments/code_constructs/EXTERNAL_APPLICATION.md
+++ b/docs/optional_arguments/code_constructs/EXTERNAL_APPLICATION.md
@@ -1,0 +1,157 @@
+The reference files for this example are in the
+[external\_app](../../../examples/docs/optional_arguments/code_constructs/external_app) directory.
+
+The reference takes place in `/tmp/docs/optional_arguments/code_constructs`, which
+is a copy of the [code\_constructs](../../../examples/docs/optional_arguments/code_constructs)
+directory. Reported locations may differ depending on the location of the source
+files.
+
+The compilation command is :
+```
+make -C external_app build
+```
+
+The analysis command is :
+```
+make -C external_app analyze
+```
+
+The compile + analyze command is :
+```
+make -C external_app
+```
+
+## First run
+
+Code:
+```OCaml
+(* external_app_lib.mli *)
+val max : ?min:'a -> 'a -> 'a -> 'a
+val min : ?max:'a -> 'a -> 'a -> 'a
+```
+```OCaml
+(* external_app_lib.ml *)
+let max ?min x y =
+  let max x y = if x > y then x else y in
+  let res = max x y in
+  match min with
+  | None -> res
+  | Some m -> max m res
+
+let min ?max x y =
+  let min x y = if x < y then x else y in
+  let res = min x y in
+  match max with
+  | None -> res
+  | Some m -> min m res
+```
+```OCaml
+(* external_app_bin.ml *)
+let () =
+  let open External_app_lib in
+  let max = max 0 42 in
+  let min = min ~max 100 200 in
+  assert (min = max)
+```
+
+Before looking at the analysis results, let's look at the code.
+
+There are 2 functions defined and exported by `External_app_lib`: `max` and
+`min. They both have an optional argument, and both functions are used
+externally. Neither is used internally.
+Optional argument `?min` of `max` is never used. Optional argument `?max` of
+`min` is always used.
+
+Compile and analyze:
+```
+$ make -C external_app
+make: Entering directory '/tmp/docs/opt_args/code_constructs/external_app'
+ocamlopt -bin-annot external_app_lib.mli external_app_lib.ml external_app_bin.ml
+dead_code_analyzer --nothing -Oa all -On all .
+Scanning files...
+ [DONE]
+
+.> OPTIONAL ARGUMENTS: ALWAYS:
+=============================
+/tmp/docs/opt_args/code_constructs/external_app/external_app_lib.mli:3: ?max
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+.> OPTIONAL ARGUMENTS: NEVER:
+============================
+/tmp/docs/opt_args/code_constructs/external_app/external_app_lib.mli:2: ?min
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/opt_args/code_constructs/external_app'
+```
+
+As expected, `?max` is reported always used and `?min` never used.
+
+Because all the uses of the functions are outside their compilation unit, the
+analyzer reports locations in the `.mli` and not the `.ml`. This is the opposite
+of the [Internal application](./INTERNAL_APPLICATION.md) example.
+
+## Fixing the reports
+
+Code:
+```OCaml
+(* external_app_lib.mli *)
+val max : 'a -> 'a -> 'a
+val min : max:'a -> 'a -> 'a -> 'a
+```
+```OCaml
+(* external_app_lib.ml *)
+let max x y =
+  if x > y then x else y
+
+let min ~max x y =
+  let min x y = if x < y then x else y in
+  let res = min x y in
+  min max res
+```
+```OCaml
+(* external_app_bin.ml *)
+let () =
+  let open External_app_lib in
+  let max = max 0 42 in
+  let min = min ~max 100 200 in
+  assert (min = max)
+```
+
+We removed `?min` from function `max` and simplified its body.
+We transformed `?max` into a mandatory labeled argument `~max` in function `min`.
+
+The signatures of the functions in the `.mli` have been changed accordingly.
+
+Compile and analyze:
+```
+$ make -C external_app
+make: Entering directory '/tmp/docs/opt_args/code_constructs/external_app'
+ocamlopt -bin-annot external_app_lib.mli external_app_lib.ml external_app_bin.ml
+dead_code_analyzer --nothing -Oa all -On all .
+Scanning files...
+ [DONE]
+
+.> OPTIONAL ARGUMENTS: ALWAYS:
+=============================
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+.> OPTIONAL ARGUMENTS: NEVER:
+============================
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/opt_args/code_constructs/external_app'
+```
+
+The analyzer does not report anything. Our work here is done.

--- a/docs/optional_arguments/code_constructs/HIGHER_ORDER_FUNCTION.md
+++ b/docs/optional_arguments/code_constructs/HIGHER_ORDER_FUNCTION.md
@@ -1,0 +1,133 @@
+The reference files for this example are in the
+[hof](../../../examples/docs/optional_arguments/code_constructs/hof) directory.
+
+The reference takes place in `/tmp/docs/optional_arguments/code_constructs`, which
+is a copy of the [code\_constructs](../../../examples/docs/optional_arguments/code_constructs)
+directory. Reported locations may differ depending on the location of the source
+files.
+
+The compilation command is :
+```
+make -C hof build
+```
+
+The analysis command is :
+```
+make -C hof analyze
+```
+
+The compile + analyze command is :
+```
+make -C hof
+```
+
+## First run
+
+Code:
+```OCaml
+(* hof_bin.ml *)
+let map_with_index (f : ?index:int -> int -> 'a) l =
+  let f' index = f ~index in
+  List.mapi f' l
+
+let add_index ?(index = 0) x =
+  x + index
+
+let add_index l =
+  map_with_index add_index l
+```
+
+Before looking at the analysis results, let's look at the code.
+
+There are 3 functions defined at the top level :
+- `map_with_index` which takes a function as argument (`f`) and a list (`l`).
+  `f` expects an optional argument `?index` and an `int`.
+- `add_index` which takes an optional argument `?index` and an `int`
+- `add_index` which takes a list as argument. This definition shadows the previous one
+
+In the last `add_index`, the first `add_index` is passed as argument to
+`map_with_index`. Thus, `add_index`'s `?index` is used because it is required by
+the signature of `map_with_index`. The first `add_index` is not used anywhere
+else, so its `?index` optional argument is always used.
+
+Within `map_with_index`, `f`'s `?index` is always used. The analyzer tracks all
+optional arguments uses, regardless of the kind of their defining functions
+(exported, local, recursive, ...). Thus, it should report the parameter `f`'s
+`?index` as always used.
+
+Compile and analyze:
+```
+$ make -C hof
+make: Entering directory '/tmp/docs/optional_arguments/code_constructs/hof'
+ocamlopt -bin-annot hof_bin.ml
+dead_code_analyzer --nothing -Oa all -On all .
+Scanning files...
+ [DONE]
+
+.> OPTIONAL ARGUMENTS: ALWAYS:
+=============================
+/tmp/docs/optional_arguments/code_constructs/hof/hof_bin.ml:2: ?index
+/tmp/docs/optional_arguments/code_constructs/hof/hof_bin.ml:6: ?index
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+.> OPTIONAL ARGUMENTS: NEVER:
+============================
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/optional_arguments/code_constructs/hof'
+```
+
+As expected, the analyzer reports 2 `?index` as always used. The first one is
+locatted at line `2` and is the one in the signature of `map_with_index`.
+The second one is located at line 6 and isthe one of the first `add_index` function.
+
+## Fixing the reports
+
+These reports can be trivially fixed by making the optional arguments mandatory.
+
+```OCaml
+(* hof_bin.ml *)
+let map_with_index (f : index:int -> int -> 'a) l =
+  let f' index = f ~index in
+  List.mapi f' l
+
+let add_index ~index x =
+  x + index
+
+let add_index l =
+  map_with_index add_index l
+```
+
+Compile and analyze:
+```
+$ make -C hof
+make: Entering directory '/tmp/docs/optional_arguments/code_constructs/hof'
+ocamlopt -bin-annot hof_bin.ml
+dead_code_analyzer --nothing -Oa all -On all .
+Scanning files...
+ [DONE]
+
+.> OPTIONAL ARGUMENTS: ALWAYS:
+=============================
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+.> OPTIONAL ARGUMENTS: NEVER:
+============================
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/optional_arguments/code_constructs/hof'
+```
+
+The analyzer does not report anything. Our work here is done.

--- a/docs/optional_arguments/code_constructs/HIGHER_ORDER_FUNCTION.md
+++ b/docs/optional_arguments/code_constructs/HIGHER_ORDER_FUNCTION.md
@@ -51,7 +51,7 @@ the signature of `map_with_index`. The first `add_index` is not used anywhere
 else, so its `?index` optional argument is always used.
 
 Within `map_with_index`, `f`'s `?index` is always used. The analyzer tracks all
-optional arguments uses, regardless of the kind of their defining functions
+the optional arguments, regardless of the kind of their defining functions
 (exported, local, recursive, ...). Thus, it should report the parameter `f`'s
 `?index` as always used.
 
@@ -84,8 +84,8 @@ make: Leaving directory '/tmp/docs/optional_arguments/code_constructs/hof'
 ```
 
 As expected, the analyzer reports 2 `?index` as always used. The first one is
-locatted at line `2` and is the one in the signature of `map_with_index`.
-The second one is located at line 6 and isthe one of the first `add_index` function.
+located at line `2` and is the one in the signature of `map_with_index`.
+The second one is located at line 6 and is the one of the first `add_index` function.
 
 ## Fixing the reports
 

--- a/docs/optional_arguments/code_constructs/INTERNAL_APPLICATION.md
+++ b/docs/optional_arguments/code_constructs/INTERNAL_APPLICATION.md
@@ -54,7 +54,7 @@ let () =
 Before looking at the analysis results, let's look at the code.
 
 There are 2 functions defined and exported by `Internal_app_lib`: `max` and
-`min. They both have an optional argument, and both functions are used
+`min`. They both have an optional argument, and both functions are used
 internally. Neither is used externally.
 Optional argument `?min` of `max` is never used. Optional argument `?max` of
 `min` is always used.
@@ -90,7 +90,8 @@ make: Leaving directory '/tmp/docs/opt_args/code_constructs/internal_app'
 As expected, `?max` is reported always used and `?min` never used.
 
 Because all the uses of the functions are inside their compilation unit, the
-analyzer reports locations in the `.ml` and not the `.mli`.
+analyzer reports locations in the `.ml` and not the `.mli`. This is the opposite
+of the [External application](./EXTERNAL_APPLICATION.md) example.
 
 ## Fixing the reports
 
@@ -123,8 +124,8 @@ The signatures of the functions in the `.mli` have been changed accordingly.
 
 > [!NOTE]
 > Because the functions `min` and `max` are exported but not used outside their
-> compilation unit, the analyzer can report them, and we could simply remove
-> them from the `.mli`. More details available in the
+> compilation unit, the analyzer can report them as _unused exported values_,
+> and we could simply remove them from the `.mli`. More details available in the
 > [Exported values](../../exported_values/EXPORTED_VALUES.md) documentation.
 
 Compile and analyze:

--- a/docs/optional_arguments/code_constructs/INTERNAL_APPLICATION.md
+++ b/docs/optional_arguments/code_constructs/INTERNAL_APPLICATION.md
@@ -1,0 +1,156 @@
+The reference files for this example are in the
+[internal\_app](../../../examples/docs/optional_arguments/code_constructs/internal_app) directory.
+
+The reference takes place in `/tmp/docs/optional_arguments/code_constructs`, which
+is a copy of the [code\_constructs](../../../examples/docs/optional_arguments/code_constructs)
+directory. Reported locations may differ depending on the location of the source
+files.
+
+The compilation command is :
+```
+make -C internal_app build
+```
+
+The analysis command is :
+```
+make -C internal_app analyze
+```
+
+The compile + analyze command is :
+```
+make -C internal_app
+```
+
+## First run
+
+Code:
+```OCaml
+(* internal_app_lib.mli *)
+val max : ?min:'a -> 'a -> 'a -> 'a
+val min : ?max:'a -> 'a -> 'a -> 'a
+```
+```OCaml
+(* internal_app_lib.ml *)
+let max ?min x y =
+  let max x y = if x > y then x else y in
+  let res = max x y in
+  match min with
+  | None -> res
+  | Some m -> max m res
+
+let min ?max x y =
+  let min x y = if x < y then x else y in
+  let res = min x y in
+  match max with
+  | None -> res
+  | Some m -> min m res
+
+let () =
+  let max = max 0 42 in
+  let min = min ~max 100 200 in
+  assert (min = max)
+```
+
+Before looking at the analysis results, let's look at the code.
+
+There are 2 functions defined and exported by `Internal_app_lib`: `max` and
+`min. They both have an optional argument, and both functions are used
+internally. Neither is used externally.
+Optional argument `?min` of `max` is never used. Optional argument `?max` of
+`min` is always used.
+
+Compile and analyze:
+```
+$ make -C internal_app
+make: Entering directory '/tmp/docs/opt_args/code_constructs/internal_app'
+ocamlopt -bin-annot internal_app_lib.mli internal_app_lib.ml
+dead_code_analyzer --nothing -Oa all -On all .
+Scanning files...
+ [DONE]
+
+.> OPTIONAL ARGUMENTS: ALWAYS:
+=============================
+/tmp/docs/opt_args/code_constructs/internal_app/internal_app_lib.ml:9: ?max
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+.> OPTIONAL ARGUMENTS: NEVER:
+============================
+/tmp/docs/opt_args/code_constructs/internal_app/internal_app_lib.ml:2: ?min
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/opt_args/code_constructs/internal_app'
+```
+
+As expected, `?max` is reported always used and `?min` never used.
+
+Because all the uses of the functions are inside their compilation unit, the
+analyzer reports locations in the `.ml` and not the `.mli`.
+
+## Fixing the reports
+
+Code:
+```OCaml
+(* internal_app_lib.mli *)
+val max : 'a -> 'a -> 'a
+val min : max:'a -> 'a -> 'a -> 'a
+```
+```OCaml
+(* internal_app_lib.ml *)
+let max x y =
+  if x > y then x else y
+
+let min ~max x y =
+  let min x y = if x < y then x else y in
+  let res = min x y in
+  min max res
+
+let () =
+  let max = max 0 42 in
+  let min = min ~max 100 200 in
+  assert (min = max)
+```
+
+We removed `?min` from function `max` and simplified its body.
+We transformed `?max` into a mandatory labeled argument `~max` in function `min`.
+
+The signatures of the functions in the `.mli` have been changed accordingly.
+
+> [!NOTE]
+> Because the functions `min` and `max` are exported but not used outside their
+> compilation unit, the analyzer can report them, and we could simply remove
+> them from the `.mli`. More details available in the
+> [Exported values](../../exported_values/EXPORTED_VALUES.md) documentation.
+
+Compile and analyze:
+```
+$ make -C internal_app
+make: Entering directory '/tmp/docs/opt_args/code_constructs/internal_app'
+ocamlopt -bin-annot internal_app_lib.mli internal_app_lib.ml
+dead_code_analyzer --nothing -Oa all -On all .
+Scanning files...
+ [DONE]
+
+.> OPTIONAL ARGUMENTS: ALWAYS:
+=============================
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+.> OPTIONAL ARGUMENTS: NEVER:
+============================
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/opt_args/code_constructs/internal_app'
+```
+
+The analyzer does not report anything. Our work here is done.

--- a/docs/optional_arguments/code_constructs/INTEXT_APPLICATION.md
+++ b/docs/optional_arguments/code_constructs/INTEXT_APPLICATION.md
@@ -1,0 +1,256 @@
+The reference files for this example are in the
+[intext\_app](../../../examples/docs/optional_arguments/code_constructs/intext_app) directory.
+
+The reference takes place in `/tmp/docs/optional_arguments/code_constructs`, which
+is a copy of the [code\_constructs](../../../examples/docs/optional_arguments/code_constructs)
+directory. Reported locations may differ depending on the location of the source
+files.
+
+The compilation command is :
+```
+make -C intext_app build
+```
+
+The analysis command is :
+```
+make -C intext_app analyze
+```
+
+The compile + analyze command is :
+```
+make -C intext_app
+```
+
+## First run
+
+Code:
+```OCaml
+(* intext_app_lib.mli *)
+val max : ?min:'a -> 'a -> 'a -> 'a
+val min : ?max:'a -> 'a -> 'a -> 'a
+```
+```OCaml
+(* intext_app_lib.ml *)
+let max ?min x y =
+  let max x y = if x > y then x else y in
+  let res = max x y in
+  match min with
+  | None -> res
+  | Some m -> max m res
+
+let min ?max x y =
+  let min x y = if x < y then x else y in
+  let res = min x y in
+  match max with
+  | None -> res
+  | Some m -> min m res
+
+let () =
+  let max = max 0 42 in
+  let min = min ~max 100 200 in
+  assert (min = max)
+```
+```OCaml
+(* intext_app_bin.ml *)
+let () =
+  let open Intext_app_lib in
+  let min = min 0 42 in
+  let max = max ~min 100 200 in
+  assert (min = max)
+```
+
+Before looking at the analysis results, let's look at the code.
+
+There are 2 functions defined and exported by `Intext_app_lib`: `max` and
+`min. They both have an optional argument, and both functions are used
+internally and externally.
+Optional argument `?min` of `max` is never used internally and always used
+externally. Optional argument `?max` of `min` is always used internally and
+never used externally.
+
+Compile and analyze:
+```
+$ make -C intext_app
+make: Entering directory '/tmp/docs/opt_args/code_constructs/intext_app'
+ocamlopt -bin-annot intext_app_lib.mli intext_app_lib.ml intext_app_bin.ml
+dead_code_analyzer --nothing -Oa all -On all .
+Scanning files...
+ [DONE]
+
+.> OPTIONAL ARGUMENTS: ALWAYS:
+=============================
+/tmp/docs/opt_args/code_constructs/intext_app/intext_app_lib.ml:9: ?max
+/tmp/docs/opt_args/code_constructs/intext_app/intext_app_lib.mli:2: ?min
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+.> OPTIONAL ARGUMENTS: NEVER:
+============================
+/tmp/docs/opt_args/code_constructs/intext_app/intext_app_lib.ml:2: ?min
+/tmp/docs/opt_args/code_constructs/intext_app/intext_app_lib.mli:3: ?max
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/opt_args/code_constructs/intext_app'
+```
+
+The analyzer reports `?max` anbd `?min` as always used and as never used.
+The difference in the reports are locations. The optional argument `?max` is
+always used for the "internal" definition of `min` but never used by its
+exported version. Similarly, the optional argument `?min` is always used by the
+exported version of `max` but never used by for its "internal" definition.
+> [!IMPORTANT]
+> If a compilation unit has a `.mli`, the analyzer tracks internal and external
+> uses of its optional arguments separately, and, thus, reports separately the
+> their internal and exported definitions.
+> For compilation units without `.mli`, the internal and exported definitions
+> are the same so the analyzer does not distinguish internal and external uses.
+
+## Fixing the reports on `?max`
+
+`?max` is always used internally and never used externally. We can simplify the
+signature of the exported function and split the `min` function in 2 :
+- `bounded_min` which expects a mandatory labeled argument `~max`;
+- `min` which only expects 2 arguments.
+
+Code:
+```OCaml
+(* intext_app_lib.mli *)
+val max : ?min:'a -> 'a -> 'a -> 'a
+val min : 'a -> 'a -> 'a
+```
+```OCaml
+(* intext_app_lib.ml *)
+let max ?min x y =
+  let max x y = if x > y then x else y in
+  let res = max x y in
+  match min with
+  | None -> res
+  | Some m -> max m res
+
+let min x y  = if x < y then x else y
+
+let bounded_min ~max x y =
+  let res = min x y in
+  min max res
+
+let () =
+  let max = max 0 42 in
+  let min = bounded_min ~max 100 200 in
+  assert (min = max)
+```
+```OCaml
+(* intext_app_bin.ml *)
+let () =
+  let open Intext_app_lib in
+  let min = min 0 42 in
+  let max = max ~min 100 200 in
+  assert (min = max)
+```
+
+`bounded_min` is only used internally so we do not export it.
+
+Compile and analyze:
+```
+$ make -C intext_app
+make: Entering directory '/tmp/docs/opt_args/code_constructs/intext_app'
+ocamlopt -bin-annot intext_app_lib.mli intext_app_lib.ml intext_app_bin.ml
+dead_code_analyzer --nothing -Oa all -On all .
+Scanning files...
+ [DONE]
+
+.> OPTIONAL ARGUMENTS: ALWAYS:
+=============================
+/tmp/docs/opt_args/code_constructs/intext_app/intext_app_lib.mli:2: ?min
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+.> OPTIONAL ARGUMENTS: NEVER:
+============================
+/tmp/docs/opt_args/code_constructs/intext_app/intext_app_lib.ml:2: ?min
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/opt_args/code_constructs/intext_app'
+```
+
+As expected, the analyzer does not report `?max` anymore.
+
+## Fixing the reports on `?min`
+
+`?min` is always used externally and never used internally. We can strengthen
+the signature of the exported function and split the `max` function in 2 :
+- `bounded_max` which expects a mandatory labeled argument `~min`;
+- `max` which only expects 2 arguments.
+
+Code:
+```OCaml
+(* intext_app_lib.mli *)
+val bounded_max : min:'a -> 'a -> 'a -> 'a
+val min : 'a -> 'a -> 'a
+```
+```OCaml
+(* intext_app_lib.ml *)
+let max x y = if x > y then x else y
+
+let bounded_max ~min x y =
+  let res = max x y in
+  max min res
+
+let min x y  = if x < y then x else y
+
+let bounded_min ~max x y =
+  let res = min x y in
+  min max res
+
+let () =
+  let max = max 0 42 in
+  let min = bounded_min ~max 100 200 in
+  assert (min = max)
+```
+```OCaml
+(* intext_app_bin.ml *)
+let () =
+  let open Intext_app_lib in
+  let min = min 0 42 in
+  let max = bounded_max ~min 100 200 in
+  assert (min = max)
+```
+
+`max` is only used internally so we do not export it.
+
+Compile and analyze:
+```
+$ make -C intext_app
+make: Entering directory '/tmp/docs/opt_args/code_constructs/intext_app'
+ocamlopt -bin-annot intext_app_lib.mli intext_app_lib.ml intext_app_bin.ml
+dead_code_analyzer --nothing -Oa all -On all .
+Scanning files...
+ [DONE]
+
+.> OPTIONAL ARGUMENTS: ALWAYS:
+=============================
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+.> OPTIONAL ARGUMENTS: NEVER:
+============================
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/opt_args/code_constructs/intext_app'
+```
+
+The analyzer does not report anything. Our work here is done.

--- a/docs/optional_arguments/code_constructs/INTEXT_APPLICATION.md
+++ b/docs/optional_arguments/code_constructs/INTEXT_APPLICATION.md
@@ -62,7 +62,7 @@ let () =
 Before looking at the analysis results, let's look at the code.
 
 There are 2 functions defined and exported by `Intext_app_lib`: `max` and
-`min. They both have an optional argument, and both functions are used
+`min`. They both have an optional argument, and both functions are used
 internally and externally.
 Optional argument `?min` of `max` is never used internally and always used
 externally. Optional argument `?max` of `min` is always used internally and
@@ -98,23 +98,25 @@ Nothing else to report in this section
 make: Leaving directory '/tmp/docs/opt_args/code_constructs/intext_app'
 ```
 
-The analyzer reports `?max` anbd `?min` as always used and as never used.
-The difference in the reports are locations. The optional argument `?max` is
-always used for the "internal" definition of `min` but never used by its
-exported version. Similarly, the optional argument `?min` is always used by the
-exported version of `max` but never used by for its "internal" definition.
+The analyzer reports `?max` and `?min` both as always used and as never used.
+The difference in the reports are locations. The optional argument `?max` of the
+internal `min` (in the `.ml`) is always used but its exported version (in the
+`.mli`) is never used. Similarly, the optional argument `?min` of the internal
+`max` (in the `.ml`) is never used but its exported version (in the `.mli`) is
+always used.
+
 > [!IMPORTANT]
-> If a compilation unit has a `.mli`, the analyzer tracks internal and external
-> uses of its optional arguments separately, and, thus, reports separately the
-> their internal and exported definitions.
-> For compilation units without `.mli`, the internal and exported definitions
+> If a module has an explicit signature, the analyzer tracks internal and external
+> uses of its optional arguments separately, and, thus, reports separately their
+> structure and signature definitions.
+> For modules without explicit signature, the structure and signature definitions
 > are the same so the analyzer does not distinguish internal and external uses.
 
 ## Fixing the reports on `?max`
 
 `?max` is always used internally and never used externally. We can simplify the
 signature of the exported function and split the `min` function in 2 :
-- `bounded_min` which expects a mandatory labeled argument `~max`;
+- `bounded_min` which expects a mandatory labelled argument `~max`;
 - `min` which only expects 2 arguments.
 
 Code:
@@ -188,7 +190,7 @@ As expected, the analyzer does not report `?max` anymore.
 
 `?min` is always used externally and never used internally. We can strengthen
 the signature of the exported function and split the `max` function in 2 :
-- `bounded_max` which expects a mandatory labeled argument `~min`;
+- `bounded_max` which expects a mandatory labelled argument `~min`;
 - `max` which only expects 2 arguments.
 
 Code:

--- a/docs/optional_arguments/code_constructs/PARTIAL_APP.md
+++ b/docs/optional_arguments/code_constructs/PARTIAL_APP.md
@@ -34,14 +34,13 @@ let sum ?x ?y () =
   | None, None -> 0
 
 let () =
-  let x = 42 in
-  let sum_x = sum ~x in
-  ignore (_sum_x)
+  let _sum_x = sum ~x:42 in
+  ()
 ```
 
 Before looking at the analysis results, let's look at the code.
 
-There is one function defined `sum` with 2 optional arguments `?x` and `?y`, and
+There is one function defined: `sum` with 2 optional arguments `?x` and `?y`, and
 1 mandatory argument `()`. The function is called once without any mandatory
 argument provided. Thus, `sum` is partially applied. The only optional argument
 with a value is `?x`.

--- a/docs/optional_arguments/code_constructs/PARTIAL_APP.md
+++ b/docs/optional_arguments/code_constructs/PARTIAL_APP.md
@@ -1,0 +1,83 @@
+The reference files for this example are in the
+[partial\_app](../../../examples/docs/optional_arguments/code_constructs/partial_app) directory.
+
+The reference takes place in `/tmp/docs/optional_arguments/code_constructs`, which
+is a copy of the [code\_constructs](../../../examples/docs/optional_arguments/code_constructs)
+directory. Reported locations may differ depending on the location of the source
+files.
+
+The compilation command is :
+```
+make -C partial_app build
+```
+
+The analysis command is :
+```
+make -C partial_app analyze
+```
+
+The compile + analyze command is :
+```
+make -C partial_app
+```
+
+## First run
+
+Code:
+```OCaml
+(* partial_app_bin.ml *)
+let sum ?x ?y () =
+  match x, y with
+  | Some x, Some y -> x + y
+  | Some x, None -> x
+  | None, Some y -> y
+  | None, None -> 0
+
+let () =
+  let x = 42 in
+  let sum_x = sum ~x in
+  ignore (_sum_x)
+```
+
+Before looking at the analysis results, let's look at the code.
+
+There is one function defined `sum` with 2 optional arguments `?x` and `?y`, and
+1 mandatory argument `()`. The function is called once without any mandatory
+argument provided. Thus, `sum` is partially applied. The only optional argument
+with a value is `?x`.
+Consequently, `?x` is always used (a value is provided for each application of
+`sum`). Because the function is only partially applied, `?y` is neither used nor
+discarded. The type of `_sum_x` is `?y:int -> unit -> int` showing that `?y`
+is still expected.
+
+Compile and analyze:
+```
+$ make -C partial_app
+make: Entering directory '/tmp/docs/optional_arguments/code_constructs/partial_app'
+ocamlopt -bin-annot partial_app_bin.ml
+dead_code_analyzer --nothing -Oa all -On all .
+Scanning files...
+ [DONE]
+
+.> OPTIONAL ARGUMENTS: ALWAYS:
+=============================
+/tmp/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml:2: ?x
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+.> OPTIONAL ARGUMENTS: NEVER:
+============================
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/optional_arguments/code_constructs/partial_app'
+```
+
+As expected, `?x` is reported as always used and `?y` is not reported.
+Fixing the report is the same as for the
+[Total application](./code_constructs/TOTAL_APP.md) example.
+Our work here is done.

--- a/docs/optional_arguments/code_constructs/TOTAL_APP.md
+++ b/docs/optional_arguments/code_constructs/TOTAL_APP.md
@@ -1,0 +1,203 @@
+The reference files for this example are in the
+[total\_app](../../../examples/docs/optional_arguments/code_constructs/total_app) directory.
+
+The reference takes place in `/tmp/docs/optional_arguments/code_constructs`, which
+is a copy of the [code\_constructs](../../../examples/docs/optional_arguments/code_constructs)
+directory. Reported locations may differ depending on the location of the source
+files.
+
+The compilation command is :
+```
+make -C total_app build
+```
+
+The analysis command is :
+```
+make -C total_app analyze
+```
+
+The compile + analyze command is :
+```
+make -C total_app
+```
+
+## First run
+
+Code:
+```OCaml
+(* total_app_bin.ml *)
+let sum ?x ?y () =
+  match x, y with
+  | Some x, Some y -> x + y
+  | Some x, None -> x
+  | None, Some y -> y
+  | None, None -> 0
+
+let () =
+  let x = 42 in
+  let x' = sum ~x () in
+  assert (x' = x)
+```
+
+Before looking at the analysis results, let's look at the code.
+
+There is one function defined `sum` with 2 optional arguments `?x` and `?y`, and
+1 mandatory argument `()`. The function is called once with all the mandatory
+arguments provided. Thus, `sum` is totally applied. The only optional argument
+with a value is `?x`.
+Consequently, `?x` is always used (a value is provided for each application of
+`sum`), and `?y` is never used (a value is never provided when applying `sum`).
+
+Compile and analyze:
+```
+$ make -C total_app
+make: Entering directory '/tmp/docs/optional_arguments/code_constructs/total_app'
+ocamlopt -bin-annot total_app_bin.ml
+dead_code_analyzer --nothing -Oa all -On all .
+Scanning files...
+ [DONE]
+
+.> OPTIONAL ARGUMENTS: ALWAYS:
+=============================
+/tmp/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?x
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+.> OPTIONAL ARGUMENTS: NEVER:
+============================
+/tmp/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/optional_arguments/code_constructs/total_app'
+```
+
+As expected, `?x` is reported as always used and `?y` as never used.
+
+> [!NOTE]
+> Although the reported locations are the ones where the arguments are defined,
+> this is coincidental. In reality, the reported locaitons are those of the
+> functions that declare the optional arguments.
+
+## Fixing the always used report
+
+Because `?x` is always used, it can be made mandatory.
+
+Code:
+```OCaml
+(* total_app_bin.ml *)
+let sum ~x ?y () =
+  match y with
+  | Some y -> x + y
+  | None -> x
+
+let () =
+  let x = 42 in
+  let x' = sum ~x () in
+  assert (x' = x)
+```
+
+Notice how we chose to make `~x` mandatory and of `int` type while the optional
+parameter `?x` was of `int option` type. Changing the type allowed us to
+simplify the code of `sum`.
+
+> [!TIP]
+> Alternatively, we could have kept the same `int option` type for `~x` and
+> updated its use in `sum ~x` by `sum ~x:(Some x)`, without changing the body of
+> `sum`. Anyway, making the argument optional implies changes in either the use
+> or the definition of the function. Otherwise the compiler would reject the
+> code with a message like :
+> ```
+> File "total_app_bin.ml", line 11, characters 16-17:
+> 11 |   let x' = sum ~x () in
+>                      ^
+> Error: This expression has type int but an expression was expected of type
+>          int option
+> ```
+
+Compile and analyze:
+```
+$ make -C total_app
+make: Entering directory '/tmp/docs/optional_arguments/code_constructs/total_app'
+ocamlopt -bin-annot total_app_bin.ml
+dead_code_analyzer --nothing -Oa all -On all .
+Scanning files...
+ [DONE]
+
+.> OPTIONAL ARGUMENTS: ALWAYS:
+=============================
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+.> OPTIONAL ARGUMENTS: NEVER:
+============================
+/tmp/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml:2: ?y
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/optional_arguments/code_constructs/total_app'
+```
+
+The analyzer does not report any optional argument as always used. It still
+reports `?y` as never unused.
+
+## Fixing the never used report
+
+Because `?y` is never used, it can be removed.
+
+Code:
+```OCaml
+(* total_app_bin.ml *)
+let sum ~x () = x
+
+let () =
+  let x = 42 in
+  let x' = sum ~x () in
+  assert (x' = x)
+```
+
+With `?y` removed from the parameters, the body of `sum` can be simplified once more.
+
+> [!TIP]
+> Because there are no more optional arguments, the `unit` argument is not
+> necessary anymore. For the purpose of the example, we'll leave the code as it
+> is. It could not have been removed in the previous iteration, even by
+> switching the positions of `~x` and `?y` because the compiler relies on the
+> application of a non-labeled argument appearing after the optional argument in
+> the function type to implicilty discard the optional argument.
+
+Compile and analyze:
+```
+$ make -C total_app
+make: Entering directory '/tmp/docs/optional_arguments/code_constructs/total_app'
+ocamlopt -bin-annot total_app_bin.ml
+dead_code_analyzer --nothing -Oa all -On all .
+Scanning files...
+ [DONE]
+
+.> OPTIONAL ARGUMENTS: ALWAYS:
+=============================
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+.> OPTIONAL ARGUMENTS: NEVER:
+============================
+
+Nothing else to report in this section
+--------------------------------------------------------------------------------
+
+
+make: Leaving directory '/tmp/docs/optional_arguments/code_constructs/total_app'
+```
+
+The analyzer does not report anything. Our work here is done.

--- a/docs/optional_arguments/code_constructs/TOTAL_APP.md
+++ b/docs/optional_arguments/code_constructs/TOTAL_APP.md
@@ -41,7 +41,7 @@ let () =
 
 Before looking at the analysis results, let's look at the code.
 
-There is one function defined `sum` with 2 optional arguments `?x` and `?y`, and
+There is one function defined: `sum` with 2 optional arguments `?x` and `?y`, and
 1 mandatory argument `()`. The function is called once with all the mandatory
 arguments provided. Thus, `sum` is totally applied. The only optional argument
 with a value is `?x`.
@@ -80,7 +80,7 @@ As expected, `?x` is reported as always used and `?y` as never used.
 
 > [!NOTE]
 > Although the reported locations are the ones where the arguments are defined,
-> this is coincidental. In reality, the reported locaitons are those of the
+> this is coincidental. In reality, the reported locations are those of the
 > functions that declare the optional arguments.
 
 ## Fixing the always used report
@@ -108,7 +108,7 @@ simplify the code of `sum`.
 > [!TIP]
 > Alternatively, we could have kept the same `int option` type for `~x` and
 > updated its use in `sum ~x` by `sum ~x:(Some x)`, without changing the body of
-> `sum`. Anyway, making the argument optional implies changes in either the use
+> `sum`. Anyway, making the argument mandatory implies changes in either the use
 > or the definition of the function. Otherwise the compiler would reject the
 > code with a message like :
 > ```
@@ -171,7 +171,7 @@ With `?y` removed from the parameters, the body of `sum` can be simplified once 
 > necessary anymore. For the purpose of the example, we'll leave the code as it
 > is. It could not have been removed in the previous iteration, even by
 > switching the positions of `~x` and `?y` because the compiler relies on the
-> application of a non-labeled argument appearing after the optional argument in
+> application of a non-labelled argument appearing after the optional argument in
 > the function type to implicilty discard the optional argument.
 
 Compile and analyze:

--- a/examples/docs/Makefile
+++ b/examples/docs/Makefile
@@ -6,10 +6,12 @@ build:
 	make -C exported_values
 	make -C methods
 	make -C fields_and_constructors
+	make -C optional_arguments
 
 clean:
 	rm -f *~ *.cm* *.o *.obj
 	make -C exported_values clean
 	make -C methods clean
 	make -C fields_and_constructors clean
+	make -C optional_arguments clean
 

--- a/examples/docs/optional_arguments/Makefile
+++ b/examples/docs/optional_arguments/Makefile
@@ -3,9 +3,11 @@
 all: build
 
 build:
+	make -C code_constructs
 	make -C limitations
 
 clean:
 	rm -f *~ *.cm* *.o *.obj
+	make -C code_constructs clean
 	make -C limitations clean
 

--- a/examples/docs/optional_arguments/Makefile
+++ b/examples/docs/optional_arguments/Makefile
@@ -1,0 +1,11 @@
+.PHONY: clean build
+
+all: build
+
+build:
+	make -C limitations
+
+clean:
+	rm -f *~ *.cm* *.o *.obj
+	make -C limitations clean
+

--- a/examples/docs/optional_arguments/code_constructs/Makefile
+++ b/examples/docs/optional_arguments/code_constructs/Makefile
@@ -5,9 +5,11 @@ all: build
 build:
 	make -C total_app build
 	make -C partial_app build
+	make -C internal_app build
 
 clean:
 	rm -f *~ *.cm* *.o *.obj
 	make -C total_app clean
 	make -C partial_app clean
+	make -C internal_app clean
 

--- a/examples/docs/optional_arguments/code_constructs/Makefile
+++ b/examples/docs/optional_arguments/code_constructs/Makefile
@@ -8,6 +8,7 @@ build:
 	make -C internal_app build
 	make -C external_app build
 	make -C intext_app build
+	make -C hof build
 
 clean:
 	rm -f *~ *.cm* *.o *.obj
@@ -16,3 +17,4 @@ clean:
 	make -C internal_app clean
 	make -C external_app clean
 	make -C intext_app clean
+	make -C hof clean

--- a/examples/docs/optional_arguments/code_constructs/Makefile
+++ b/examples/docs/optional_arguments/code_constructs/Makefile
@@ -7,6 +7,7 @@ build:
 	make -C partial_app build
 	make -C internal_app build
 	make -C external_app build
+	make -C intext_app build
 
 clean:
 	rm -f *~ *.cm* *.o *.obj
@@ -14,4 +15,4 @@ clean:
 	make -C partial_app clean
 	make -C internal_app clean
 	make -C external_app clean
-
+	make -C intext_app clean

--- a/examples/docs/optional_arguments/code_constructs/Makefile
+++ b/examples/docs/optional_arguments/code_constructs/Makefile
@@ -6,10 +6,12 @@ build:
 	make -C total_app build
 	make -C partial_app build
 	make -C internal_app build
+	make -C external_app build
 
 clean:
 	rm -f *~ *.cm* *.o *.obj
 	make -C total_app clean
 	make -C partial_app clean
 	make -C internal_app clean
+	make -C external_app clean
 

--- a/examples/docs/optional_arguments/code_constructs/Makefile
+++ b/examples/docs/optional_arguments/code_constructs/Makefile
@@ -4,8 +4,10 @@ all: build
 
 build:
 	make -C total_app build
+	make -C partial_app build
 
 clean:
 	rm -f *~ *.cm* *.o *.obj
 	make -C total_app clean
+	make -C partial_app clean
 

--- a/examples/docs/optional_arguments/code_constructs/Makefile
+++ b/examples/docs/optional_arguments/code_constructs/Makefile
@@ -1,0 +1,11 @@
+.PHONY: clean build
+
+all: build
+
+build:
+	make -C total_app build
+
+clean:
+	rm -f *~ *.cm* *.o *.obj
+	make -C total_app clean
+

--- a/examples/docs/optional_arguments/code_constructs/external_app/Makefile
+++ b/examples/docs/optional_arguments/code_constructs/external_app/Makefile
@@ -1,0 +1,12 @@
+SRC:=external_app_lib.mli external_app_lib.ml external_app_bin.ml
+
+all: build analyze
+
+build:
+	ocamlopt -bin-annot ${SRC}
+
+analyze:
+	dead_code_analyzer --nothing -Oa all -On all .
+
+clean:
+	rm -f *.cm* *.o a.out

--- a/examples/docs/optional_arguments/code_constructs/external_app/external_app_bin.ml
+++ b/examples/docs/optional_arguments/code_constructs/external_app/external_app_bin.ml
@@ -1,0 +1,6 @@
+(* external_app_bin.ml *)
+let () =
+  let open External_app_lib in
+  let max = max 0 42 in
+  let min = min ~max 100 200 in
+  assert (min = max)

--- a/examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.ml
+++ b/examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.ml
@@ -1,0 +1,14 @@
+(* external_app_lib.ml *)
+let max ?min x y =
+  let max x y = if x > y then x else y in
+  let res = max x y in
+  match min with
+  | None -> res
+  | Some m -> max m res
+
+let min ?max x y =
+  let min x y = if x < y then x else y in
+  let res = min x y in
+  match max with
+  | None -> res
+  | Some m -> min m res

--- a/examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli
+++ b/examples/docs/optional_arguments/code_constructs/external_app/external_app_lib.mli
@@ -1,0 +1,3 @@
+(* external_app_lib.mli *)
+val max : ?min:'a -> 'a -> 'a -> 'a
+val min : ?max:'a -> 'a -> 'a -> 'a

--- a/examples/docs/optional_arguments/code_constructs/hof/Makefile
+++ b/examples/docs/optional_arguments/code_constructs/hof/Makefile
@@ -1,0 +1,12 @@
+SRC:=hof_bin.ml
+
+all: build analyze
+
+build:
+	ocamlopt -bin-annot ${SRC}
+
+analyze:
+	dead_code_analyzer --nothing -Oa all -On all .
+
+clean:
+	rm -f *.cm* *.o a.out

--- a/examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml
+++ b/examples/docs/optional_arguments/code_constructs/hof/hof_bin.ml
@@ -1,0 +1,10 @@
+(* hof_bin.ml *)
+let map_with_index (f : ?index:int -> int -> 'a) l =
+  let f' index = f ~index in
+  List.mapi f' l
+
+let add_index ?(index = 0) x =
+  x + index
+
+let add_index l =
+  map_with_index add_index l

--- a/examples/docs/optional_arguments/code_constructs/internal_app/Makefile
+++ b/examples/docs/optional_arguments/code_constructs/internal_app/Makefile
@@ -1,0 +1,12 @@
+SRC:=internal_app_lib.mli internal_app_lib.ml
+
+all: build analyze
+
+build:
+	ocamlopt -bin-annot ${SRC}
+
+analyze:
+	dead_code_analyzer --nothing -Oa all -On all .
+
+clean:
+	rm -f *.cm* *.o a.out

--- a/examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml
+++ b/examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.ml
@@ -1,0 +1,19 @@
+(* internal_app_lib.ml *)
+let max ?min x y =
+  let max x y = if x > y then x else y in
+  let res = max x y in
+  match min with
+  | None -> res
+  | Some m -> max m res
+
+let min ?max x y =
+  let min x y = if x < y then x else y in
+  let res = min x y in
+  match max with
+  | None -> res
+  | Some m -> min m res
+
+let () =
+  let max = max 0 42 in
+  let min = min ~max 100 200 in
+  assert (min = max)

--- a/examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli
+++ b/examples/docs/optional_arguments/code_constructs/internal_app/internal_app_lib.mli
@@ -1,0 +1,3 @@
+(* internal_app_lib.mli *)
+val max : ?min:'a -> 'a -> 'a -> 'a
+val min : ?max:'a -> 'a -> 'a -> 'a

--- a/examples/docs/optional_arguments/code_constructs/intext_app/Makefile
+++ b/examples/docs/optional_arguments/code_constructs/intext_app/Makefile
@@ -1,0 +1,12 @@
+SRC:=intext_app_lib.mli intext_app_lib.ml intext_app_bin.ml
+
+all: build analyze
+
+build:
+	ocamlopt -bin-annot ${SRC}
+
+analyze:
+	dead_code_analyzer --nothing -Oa all -On all .
+
+clean:
+	rm -f *.cm* *.o a.out

--- a/examples/docs/optional_arguments/code_constructs/intext_app/intext_app_bin.ml
+++ b/examples/docs/optional_arguments/code_constructs/intext_app/intext_app_bin.ml
@@ -1,0 +1,6 @@
+(* intext_app_bin.ml *)
+let () =
+  let open Intext_app_lib in
+  let min = min 0 42 in
+  let max = max ~min 100 200 in
+  assert (min = max)

--- a/examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.ml
+++ b/examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.ml
@@ -1,0 +1,19 @@
+(* intext_app_lib.ml *)
+let max ?min x y =
+  let max x y = if x > y then x else y in
+  let res = max x y in
+  match min with
+  | None -> res
+  | Some m -> max m res
+
+let min ?max x y =
+  let min x y = if x < y then x else y in
+  let res = min x y in
+  match max with
+  | None -> res
+  | Some m -> min m res
+
+let () =
+  let max = max 0 42 in
+  let min = min ~max 100 200 in
+  assert (min = max)

--- a/examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.mli
+++ b/examples/docs/optional_arguments/code_constructs/intext_app/intext_app_lib.mli
@@ -1,0 +1,3 @@
+(* intext_app_lib.mli *)
+val max : ?min:'a -> 'a -> 'a -> 'a
+val min : ?max:'a -> 'a -> 'a -> 'a

--- a/examples/docs/optional_arguments/code_constructs/partial_app/Makefile
+++ b/examples/docs/optional_arguments/code_constructs/partial_app/Makefile
@@ -1,0 +1,12 @@
+SRC:=partial_app_bin.ml
+
+all: build analyze
+
+build:
+	ocamlopt -bin-annot ${SRC}
+
+analyze:
+	dead_code_analyzer --nothing -Oa all -On all .
+
+clean:
+	rm -f *.cm* *.o a.out

--- a/examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml
+++ b/examples/docs/optional_arguments/code_constructs/partial_app/partial_app_bin.ml
@@ -1,0 +1,11 @@
+(* partial_app_bin.ml *)
+let sum ?x ?y () =
+  match x, y with
+  | Some x, Some y -> x + y
+  | Some x, None -> x
+  | None, Some y -> y
+  | None, None -> 0
+
+let () =
+  let _sum_x = sum ~x:42 in
+  ()

--- a/examples/docs/optional_arguments/code_constructs/total_app/Makefile
+++ b/examples/docs/optional_arguments/code_constructs/total_app/Makefile
@@ -1,0 +1,12 @@
+SRC:=total_app_bin.ml
+
+all: build analyze
+
+build:
+	ocamlopt -bin-annot ${SRC}
+
+analyze:
+	dead_code_analyzer --nothing -Oa all -On all .
+
+clean:
+	rm -f *.cm* *.o a.out

--- a/examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml
+++ b/examples/docs/optional_arguments/code_constructs/total_app/total_app_bin.ml
@@ -1,0 +1,12 @@
+(* total_app_bin.ml *)
+let sum ?x ?y () =
+  match x, y with
+  | Some x, Some y -> x + y
+  | Some x, None -> x
+  | None, Some y -> y
+  | None, None -> 0
+
+let () =
+  let x = 42 in
+  let x' = sum ~x () in
+  assert (x' = x)

--- a/examples/docs/optional_arguments/limitations/Makefile
+++ b/examples/docs/optional_arguments/limitations/Makefile
@@ -1,0 +1,11 @@
+.PHONY: clean build
+
+all: build
+
+build:
+	make -C relaying build
+
+clean:
+	rm -f *~ *.cm* *.o *.obj
+	make -C relaying clean
+

--- a/examples/docs/optional_arguments/limitations/relaying/Makefile
+++ b/examples/docs/optional_arguments/limitations/relaying/Makefile
@@ -1,0 +1,12 @@
+SRC:=relaying_bin.ml
+
+all: build analyze
+
+build:
+	ocamlopt -bin-annot ${SRC}
+
+analyze:
+	dead_code_analyzer --nothing -Oa all -On all .
+
+clean:
+	rm -f *.cm* *.o a.out

--- a/examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml
+++ b/examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml
@@ -1,0 +1,8 @@
+(* relaying_bin.ml *)
+let f ?x () = ignore x
+
+let g ?x () = f ?x ()
+
+let () =
+  f ~x:42 ();
+  g ()


### PR DESCRIPTION
Fix https://github.com/LexiFi/dead_code_analyzer/issues/61

The new documentation provides some preliminary definitions to understand what the analyzer tracks and may report in the optional arguments always/never used sections.
It also provides examples focusing on different simple code constructs (partial application, higher-order-function, ...), and document known limitations.

The code of the examples explored in the .md files is also provided in its own files to ease user experimentation, and is included in the testsuite.