### PR TITLE
Fix uncaught exception with anonymous submodules

### DIFF
--- a/examples/using_dune/lib/values/values_in_submodules.ml
+++ b/examples/using_dune/lib/values/values_in_submodules.ml
@@ -16,6 +16,10 @@ module Exported = struct
 
 end
 
+module _ = struct
+  let unused_int = 42
+end
+
 let () = ignore Unexported.used_int
 
 let () = ignore Exported.Private.used_int

--- a/src/deadCode.ml
+++ b/src/deadCode.ml
@@ -208,7 +208,7 @@ let structure_item super self i =
   end;
   let r = super.Tast_mapper.structure_item self i in
   begin match i.str_desc with
-  | Tstr_module _ -> mods := List.tl !mods
+  | Tstr_module {mb_name = {txt = Some _; _}; _} -> mods := List.tl !mods
   | _ -> ()
   end;
   r


### PR DESCRIPTION
An exception was raised when analyzing a module with

```
module _ = struct ... end
(* or *)
module _ = Functor_with_side_effects(X)
```

Feel free to cherry-pick or modify these commits as you wish.