### PR TITLE
Some tests break with ppx_deriving.6.1.2

### DIFF
--- a/check/classic/classic.ref
+++ b/check/classic/classic.ref
@@ -52,6 +52,8 @@
 
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:1: unused
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:3: internally_used
+./examples/using_dune/preprocessed_lib/preprocessed.mli:19: equal_constr_with_eq: Should not be detected
+./examples/using_dune/preprocessed_lib/preprocessed.mli:29: equal_record_with_eq: Should not be detected
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:38: internally_used_f
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:2: unused
 
@@ -719,7 +721,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 593
+Total: 595
 Success: 586
-Failed: 7
-Ratio: 98.8195615514%
+Failed: 9
+Ratio: 98.487394958%

--- a/check/threshold-1/threshold-1.ref
+++ b/check/threshold-1/threshold-1.ref
@@ -244,9 +244,10 @@
 
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:3: internally_used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:4: externally_used
+./examples/using_dune/preprocessed_lib/preprocessed.mli:19: equal_constr_with_eq: Should not be detected
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:4: internally_used
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:5: externally_used
-
+./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:30: equal_constr_with_eq: Should not be detected
 ./examples/using_dune/reduced_lib/reduced_lib.mli:2: Values.used
 ./examples/using_dune/reduced_lib/reduced_lib.mli:5: Values.externally_used
 ./examples/using_dune/reduced_lib/reduced_lib.mli:9: Values_no_intf.used
@@ -1127,7 +1128,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 929
+Total: 931
 Success: 921
-Failed: 8
-Ratio: 99.1388589882%
+Failed: 10
+Ratio: 98.9258861439%

--- a/check/threshold-3-0.5/threshold-3-0.5.ref
+++ b/check/threshold-3-0.5/threshold-3-0.5.ref
@@ -244,9 +244,10 @@
 
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:3: internally_used
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:4: externally_used
+./examples/using_dune/preprocessed_lib/preprocessed.mli:19: equal_constr_with_eq: Should not be detected
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:4: internally_used
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:5: externally_used
-
+./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:30: equal_constr_with_eq: Should not be detected
 ./examples/using_dune/reduced_lib/reduced_lib.mli:2: Values.used
 ./examples/using_dune/reduced_lib/reduced_lib.mli:5: Values.externally_used
 ./examples/using_dune/reduced_lib/reduced_lib.mli:9: Values_no_intf.used
@@ -415,10 +416,12 @@
 ./examples/docs/optional_arguments/limitations/relaying/relaying_bin.ml:2: f
 
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:2: used
+./examples/using_dune/preprocessed_lib/preprocessed.mli:29: equal_record_with_eq: Should not be detected
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:31: exported_f
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:38: internally_used_f
 ./examples/using_dune/preprocessed_lib/preprocessed.mli:44: externally_used_f
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:3: used
+./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:45: equal_record_with_eq: Should not be detected
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:53: f
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:59: internally_used_f
 ./examples/using_dune/preprocessed_lib/preprocessed_no_intf.ml:64: externally_used_f
@@ -1531,7 +1534,7 @@ Nothing else to report in this section
 --------------------------------------------------------------------------------
 
 
-Total: 1251
+Total: 1255
 Success: 1243
-Failed: 8
-Ratio: 99.3605115907%
+Failed: 12
+Ratio: 99.0438247012%


### PR DESCRIPTION
ppx_deriving generated code used to have a dummy location, which is a loc_ghost. Thus, its content was not tracked by the analyzer.
Since https://github.com/ocaml-ppx/ppx_deriving/pull/297, it holds more coherent locations (the one of the ppx-ed type_decl). Because the generated code is basically an `include (struct ... end)` in .ml and `include (sig ... end)` in .mli, the included content appears inlined in cmi, and indistinguishable from user-written content at this place.

I don't think we need to worry too much about ppx generated code that gets reported (for now). I think its locations should always be loc_ghosts but it is not enforced, and, as a result, any ppx may lead to false positives. The best we can do is, when such a false positive appears, try and fix the concerned ppx to generate loc_ghosts.